### PR TITLE
refactor(notifications): better handling of read and pagination

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 ## Neste versjon
 
+- ⚡ **Pagination i varsler**. Lagt til pagination i varsler, samt forbedret håndtering av "leste" varsler.
 - ⚡ **Refaktorert checkbox og switch**. Laget en egen komponent for checkboxes og switches som lettere kan brukes med react-hook-form
 - 🎨 **Nytt design av QRcode.** Laget custom QRcode theme for mer helhetlig tema.
 

--- a/src/api/api.tsx
+++ b/src/api/api.tsx
@@ -12,6 +12,7 @@ import {
   JobPostRequired,
   News,
   NewsRequired,
+  Notification,
   Category,
   Warning,
   RequestResponse,
@@ -74,7 +75,8 @@ export default {
   updateUserData: (userName: string, item: Partial<User>) => IFetch<User>({ method: 'PUT', url: `user/${userName}/`, data: item }),
 
   // Notifications
-  updateNotification: (id: number, item: { read: boolean }) => IFetch<RequestResponse>({ method: 'PUT', url: `notification/${String(id)}/`, data: item }),
+  getNotifications: (filters?: any) => IFetch<PaginationResponse<Notification>>({ method: 'GET', url: `notification/`, data: filters || {} }),
+  updateNotification: (id: number, item: { read: boolean }) => IFetch<Notification>({ method: 'PUT', url: `notification/${String(id)}/`, data: item }),
 
   // Cheatsheet
   getCheatsheets: (study: Study, grade: number, filters?: any) => {

--- a/src/api/hooks/News.tsx
+++ b/src/api/hooks/News.tsx
@@ -8,7 +8,6 @@ export const useNewsById = (id: number) => {
   return useQuery<News, RequestResponse>([QUERY_KEY, id], () => API.getNewsItem(id), { enabled: id !== -1 });
 };
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const useNews = () => {
   return useInfiniteQuery<PaginationResponse<News>, RequestResponse>([QUERY_KEY], ({ pageParam = 1 }) => API.getNewsItems({ page: pageParam }), {
     getNextPageParam: (lastPage) => lastPage.next,

--- a/src/api/hooks/Notification.tsx
+++ b/src/api/hooks/Notification.tsx
@@ -1,7 +1,27 @@
-import { useCallback } from 'react';
+import { useMutation, useInfiniteQuery, useQueryClient, UseMutationResult } from 'react-query';
 import API from 'api/api';
+import { Notification, PaginationResponse, RequestResponse } from 'types/Types';
+import { USER_QUERY_KEY } from 'api/hooks/User';
 
-export const useNotification = () => {
-  const updateNotificationReadState = useCallback(async (id: number, newReadState: boolean) => API.updateNotification(id, { read: newReadState }), []);
-  return { updateNotificationReadState };
+export const NOTIFICATION_QUERY_KEY = 'notification';
+
+export const useNotifications = () => {
+  return useInfiniteQuery<PaginationResponse<Notification>, RequestResponse>(
+    [NOTIFICATION_QUERY_KEY],
+    ({ pageParam = 1 }) => API.getNotifications({ page: pageParam }),
+    {
+      getNextPageParam: (lastPage) => lastPage.next,
+    },
+  );
+};
+
+export const useUpdateNotification = (id: number): UseMutationResult<Notification, RequestResponse, boolean, unknown> => {
+  const queryClient = useQueryClient();
+  return useMutation((newReadState: boolean) => API.updateNotification(id, { read: newReadState }), {
+    onSuccess: () => {
+      queryClient.invalidateQueries(NOTIFICATION_QUERY_KEY);
+      queryClient.invalidateQueries(USER_QUERY_KEY);
+      // queryClient.setQueryData([NOTIFICATION_QUERY_KEY, id], data);
+    },
+  });
 };

--- a/src/api/hooks/User.tsx
+++ b/src/api/hooks/User.tsx
@@ -6,18 +6,18 @@ import { Groups } from 'types/Enums';
 import { getCookie, setCookie, removeCookie } from 'api/cookie';
 import { ACCESS_TOKEN } from 'constant';
 
-const QUERY_KEY = 'user';
+export const USER_QUERY_KEY = 'user';
 const QUERY_KEY_USERS = 'users';
 
 export const useUser = () => {
   const isAuthenticated = useIsAuthenticated();
-  return useQuery<User | undefined, RequestResponse>(QUERY_KEY, () => (isAuthenticated ? API.getUserData() : undefined));
+  return useQuery<User | undefined, RequestResponse>(USER_QUERY_KEY, () => (isAuthenticated ? API.getUserData() : undefined));
 };
 
 export const useRefreshUser = () => {
   const queryClient = useQueryClient();
   return () => {
-    queryClient.invalidateQueries(QUERY_KEY);
+    queryClient.invalidateQueries(USER_QUERY_KEY);
   };
 };
 
@@ -37,8 +37,8 @@ export const useLogin = (): UseMutationResult<LoginRequestResponse, RequestRespo
   return useMutation(({ username, password }) => API.authenticate(username, password), {
     onSuccess: (data) => {
       setCookie(ACCESS_TOKEN, data.token);
-      queryClient.removeQueries(QUERY_KEY);
-      queryClient.prefetchQuery(QUERY_KEY, () => API.getUserData());
+      queryClient.removeQueries(USER_QUERY_KEY);
+      queryClient.prefetchQuery(USER_QUERY_KEY, () => API.getUserData());
     },
   });
 };
@@ -51,7 +51,7 @@ export const useLogout = () => {
   const queryClient = useQueryClient();
   return () => {
     removeCookie(ACCESS_TOKEN);
-    queryClient.removeQueries(QUERY_KEY);
+    queryClient.removeQueries(USER_QUERY_KEY);
   };
 };
 
@@ -68,9 +68,9 @@ export const useUpdateUser = (): UseMutationResult<User, RequestResponse, { user
   return useMutation(({ userId, user }) => API.updateUserData(userId, user), {
     onSuccess: (data) => {
       queryClient.invalidateQueries(QUERY_KEY_USERS);
-      const user = queryClient.getQueryData<User | undefined>(QUERY_KEY);
+      const user = queryClient.getQueryData<User | undefined>(USER_QUERY_KEY);
       if (data.user_id === user?.user_id) {
-        queryClient.setQueryData(QUERY_KEY, data);
+        queryClient.setQueryData(USER_QUERY_KEY, data);
       }
     },
   });

--- a/src/containers/Profile/components/ProfileNotifications.tsx
+++ b/src/containers/Profile/components/ProfileNotifications.tsx
@@ -1,14 +1,23 @@
+import { Fragment, useEffect, useMemo } from 'react';
+import classNames from 'classnames';
+import parseISO from 'date-fns/parseISO';
 import { Notification } from 'types/Types';
-import { useNotification } from 'api/hooks/Notification';
+import { useNotifications, useUpdateNotification } from 'api/hooks/Notification';
+import { getTimeSince } from 'utils';
 
 // Material-UI
-import classNames from 'classnames';
 import { makeStyles } from '@material-ui/core/styles';
 import Typography from '@material-ui/core/Typography';
-import InfoIcon from '@material-ui/icons/InfoRounded';
+import Skeleton from '@material-ui/lab/Skeleton';
+
+// Icons
+import NotificationUnreadIcon from '@material-ui/icons/NotificationsRounded';
+import NotificationReadIcon from '@material-ui/icons/NotificationsNoneRounded';
 
 // Project components
+import NotFoundIndicator from 'components/miscellaneous/NotFoundIndicator';
 import Paper from 'components/layout/Paper';
+import Pagination from 'components/layout/Pagination';
 
 const useStyles = makeStyles((theme) => ({
   message: {
@@ -16,10 +25,6 @@ const useStyles = makeStyles((theme) => ({
     alignItems: 'center',
     padding: theme.spacing(1),
     marginBottom: theme.spacing(1),
-    '& div': {
-      width: '100%',
-      padding: theme.spacing(1),
-    },
   },
   icon: {
     fontSize: 25,
@@ -28,7 +33,7 @@ const useStyles = makeStyles((theme) => ({
     color: theme.palette.text.secondary,
   },
   unread: {
-    backgroundColor: theme.palette.colors.tihlde + '44',
+    backgroundColor: theme.palette.colors.tihlde + '25',
   },
   text: {
     color: theme.palette.text.primary,
@@ -41,43 +46,62 @@ type NotificationItemProps = {
 
 const NotificationItem = ({ notification }: NotificationItemProps) => {
   const classes = useStyles();
-  const { updateNotificationReadState } = useNotification();
+  const updateNotification = useUpdateNotification(notification.id);
 
-  if (!notification.read) {
-    updateNotificationReadState(notification.id, true);
-  }
+  useEffect(() => {
+    return () => {
+      if (!notification.read) {
+        updateNotification.mutate(true);
+      }
+    };
+  }, [notification]);
 
+  const Icon = notification.read ? NotificationReadIcon : NotificationUnreadIcon;
   return (
     <Paper className={classNames(classes.message, !notification.read && classes.unread)}>
-      <InfoIcon className={classes.icon} />
-      <Typography align='left' className={classes.text} color='inherit'>
-        {notification.message}
-      </Typography>
+      <Icon className={classes.icon} />
+      <div style={{ width: '100%' }}>
+        <Typography className={classes.text}>{notification.message}</Typography>
+        <Typography variant='caption'>{getTimeSince(parseISO(notification.created_at))}</Typography>
+      </div>
     </Paper>
   );
 };
 
-export type ProfileNotificationsProps = {
-  notifications: Array<Notification>;
-  isLoading: boolean;
+const NotificationItemLoading = () => {
+  const classes = useStyles();
+  return (
+    <Paper className={classes.message}>
+      <NotificationReadIcon className={classes.icon} />
+      <div style={{ width: '100%' }}>
+        <Skeleton height={24} width='40%' />
+        <Skeleton height={12} width='15%' />
+      </div>
+    </Paper>
+  );
 };
 
-const ProfileNotifications = ({ notifications, isLoading }: ProfileNotificationsProps) => {
-  const classes = useStyles();
+const ProfileNotifications = () => {
+  const { data, error, hasNextPage, fetchNextPage, isLoading, isFetching } = useNotifications();
+  const isEmpty = useMemo(() => (data !== undefined ? !data.pages.some((page) => Boolean(page.results.length)) : false), [data]);
 
   return (
     <>
-      {isLoading ? (
-        <Typography align='center' className={classes.text} variant='subtitle1'>
-          Laster notifikasjoner...
-        </Typography>
-      ) : notifications.length ? (
-        notifications.map((notification) => <NotificationItem key={notification.id} notification={notification} />)
-      ) : (
-        <Typography align='center' className={classes.text} variant='subtitle1'>
-          Ingen notifikasjoner
-        </Typography>
+      {isLoading && <NotificationItemLoading />}
+      {isEmpty && <NotFoundIndicator header='Fant ingen varsler' />}
+      {error && <Paper>{error.detail}</Paper>}
+      {data !== undefined && (
+        <Pagination fullWidth hasNextPage={hasNextPage} isLoading={isFetching} nextPage={() => fetchNextPage()}>
+          {data.pages.map((page, i) => (
+            <Fragment key={i}>
+              {page.results.map((notification) => (
+                <NotificationItem key={notification.id} notification={notification} />
+              ))}
+            </Fragment>
+          ))}
+        </Pagination>
       )}
+      {isFetching && <NotificationItemLoading />}
     </>
   );
 };

--- a/src/containers/Profile/components/ProfilePaper.tsx
+++ b/src/containers/Profile/components/ProfilePaper.tsx
@@ -105,7 +105,7 @@ export type ProfilePaperProps = { logoutMethod: () => void };
 
 const ProfilePaper = ({ logoutMethod }: ProfilePaperProps) => {
   const classes = useStyles();
-  const { data: user, isLoading } = useUser();
+  const { data: user } = useUser();
   const { allowAccess: isAdmin } = useHavePermission([Groups.HS, Groups.PROMO, Groups.INDEX, Groups.NOK]);
   const [showModal, setShowModal] = useState(false);
   const eventTab = { label: 'Arrangementer', icon: EventIcon };
@@ -188,8 +188,8 @@ const ProfilePaper = ({ logoutMethod }: ProfilePaperProps) => {
           <Collapse in={tab === eventTab.label}>
             <ProfileEvents />
           </Collapse>
-          <Collapse in={tab === notificationsTab.label}>
-            <ProfileNotifications isLoading={isLoading} notifications={user?.notifications.sort((a, b) => b.id - a.id) || []} />
+          <Collapse in={tab === notificationsTab.label} unmountOnExit>
+            <ProfileNotifications />
           </Collapse>
           <Collapse in={tab === badgesTab.label}>
             <ProfileBadges />

--- a/src/types/Types.tsx
+++ b/src/types/Types.tsx
@@ -41,7 +41,6 @@ export interface User {
   events: Array<EventCompact>;
   groups: Array<Groups>;
   unread_notifications: number;
-  notifications: Array<Notification>;
   badges: Array<Badge>;
 }
 export type UserCreate = Pick<User, 'email' | 'first_name' | 'last_name' | 'user_class' | 'user_id' | 'user_study'> & {
@@ -61,6 +60,7 @@ export interface Notification {
   id: number;
   read: boolean;
   message: string;
+  created_at: string;
 }
 
 export type NewsRequired = Partial<News> & Pick<News, 'title' | 'header' | 'body'>;

--- a/src/utils.tsx
+++ b/src/utils.tsx
@@ -82,6 +82,25 @@ export const formatDate = (date: Date) => {
   );
 };
 
+export const getTimeSince = (date: Date) => {
+  const ms = new Date().getTime() - date.getTime();
+  const sec = Number((ms / 1000).toFixed(0));
+  const min = Number((ms / (1000 * 60)).toFixed(0));
+  const hrs = Number((ms / (1000 * 60 * 60)).toFixed(0));
+  const days = Number((ms / (1000 * 60 * 60 * 24)).toFixed(0));
+  if (sec < 60) {
+    return `${sec} sekunder siden`;
+  } else if (min < 60) {
+    return `${min} minutter siden`;
+  } else if (hrs < 24) {
+    return `${hrs} timer siden`;
+  } else if (days < 7) {
+    return `${days} dager siden`;
+  } else {
+    return formatDate(date);
+  }
+};
+
 export const getDay = (day: number) => {
   switch (day) {
     case 0:


### PR DESCRIPTION
## Description

Comments/issues/screenshots:
- Changed to react query
- Update read-state on unmount and refresh notifications after
- Add when notification was sent

![image](https://user-images.githubusercontent.com/31009729/109854275-2504c280-7c57-11eb-8f38-6b8225d94a02.png)


closes #428 
closes #292 
closes #422 
#368 

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [x] The PR includes a `closes #issueID`
- [x] The PR includes a picture showing visual changes
