### PR TITLE
feat(show members): Added feature

### DIFF
--- a/src/URLS.tsx
+++ b/src/URLS.tsx
@@ -4,6 +4,10 @@ export const PAGES_URLS = {
   CONTACT_US: 'kontakt-oss/',
   EVENT_RULES: 'annet/arrangementsregler/',
   NEW_STUDENT: 'ny-student/',
+  SOSIALEN: 'tihlde/undergrupper/sosialen/',
+  DRIFT: 'tihlde/undergrupper/drift/',
+  NOK: 'tihlde/undergrupper/nringsliv-og-kurs/',
+  PROMO: 'tihlde/undergrupper/promo/',
 };
 
 export default {

--- a/src/containers/Pages/index.tsx
+++ b/src/containers/Pages/index.tsx
@@ -19,6 +19,8 @@ import MarkdownRenderer from 'components/miscellaneous/MarkdownRenderer';
 import PagesAdmin from 'containers/Pages/components/PagesAdmin';
 import PagesList from 'containers/Pages/components/PagesList';
 import ShareButton from 'components/miscellaneous/ShareButton';
+import MembersCard from './specials/Index/MembersCard';
+import { Groups } from 'types/Enums';
 
 const Index = lazy(() => import('containers/Pages/specials/Index'));
 
@@ -91,6 +93,14 @@ const Pages = () => {
 
   const SpecialContent = () => {
     switch (path) {
+      case PAGES_URLS.SOSIALEN:
+        return <MembersCard slug={Groups.SOSIALEN} />;
+      case PAGES_URLS.DRIFT:
+        return <MembersCard slug={Groups.DRIFT} />;
+      case PAGES_URLS.NOK:
+        return <MembersCard slug={Groups.NOK} />;
+      case PAGES_URLS.PROMO:
+        return <MembersCard slug={Groups.PROMO} />;
       case PAGES_URLS.ABOUT_INDEX:
         return <Index />;
       default:

--- a/src/containers/Pages/specials/Index/MembersCard.tsx
+++ b/src/containers/Pages/specials/Index/MembersCard.tsx
@@ -40,17 +40,15 @@ const MembersCard = ({ slug }: MembersCardProps) => {
     <Paper>
       <Grid container spacing={2}>
         {leader && (
-          <>
-            <Grid item xs={12}>
-              <Typography variant='subtitle1'>
-                <b>Leder:</b>
-              </Typography>
-              <Box alignItems='center' display='flex' flexWrap='wrap'>
-                <StarIcon className={classes.icons} />
-                <Typography variant='subtitle1'>{`${leader?.user.first_name} ${leader?.user.last_name}`}</Typography>
-              </Box>
-            </Grid>
-          </>
+          <Grid item xs={12}>
+            <Typography variant='subtitle1'>
+              <b>Leder:</b>
+            </Typography>
+            <Box alignItems='center' display='flex' flexWrap='wrap'>
+              <StarIcon className={classes.icons} />
+              <Typography variant='subtitle1'>{`${leader?.user.first_name} ${leader?.user.last_name}`}</Typography>
+            </Box>
+          </Grid>
         )}
         {members && members.length > 0 && (
           <Grid item xs={12}>

--- a/src/containers/Pages/specials/Index/MembersCard.tsx
+++ b/src/containers/Pages/specials/Index/MembersCard.tsx
@@ -19,16 +19,20 @@ const useStyles = makeStyles((theme) => ({
 }));
 
 const MembersCard = ({ slug }: MembersCardProps) => {
-  const { data } = useMemberships(slug.toLowerCase());
+  const { data, isLoading } = useMemberships(slug.toLowerCase());
   const leader = data?.find((member) => member.membership_type === 'LEADER');
   const members = data?.filter((element) => element.membership_type === 'MEMBER').map((member) => `${member.user.first_name} ${member.user.last_name}`);
   const classes = useStyles();
 
-  if (!members) {
-    return <Skeleton height='100px' variant='rect' />;
+  if (isLoading) {
+    return (
+      <Paper>
+        <Skeleton height='100px' variant='rect' />
+      </Paper>
+    );
   }
 
-  if (members.length === 0 && !leader) {
+  if (!members?.length && !leader) {
     return null;
   }
 
@@ -48,23 +52,21 @@ const MembersCard = ({ slug }: MembersCardProps) => {
             </Grid>
           </>
         )}
-        {members.length > 0 && (
+        {members && members.length > 0 && (
           <Grid item xs={12}>
             <Typography variant='subtitle1'>
               <b>Medlemmer:</b>
             </Typography>
           </Grid>
         )}
-        {members.map((member) => {
+        {members?.map((member) => {
           return (
-            <>
-              <Grid item key={member} md={6} xs={12}>
-                <Box alignItems='center' display='flex' flexWrap='wrap'>
-                  <PersonIcon className={classes.icons} />
-                  <Typography variant='subtitle1'>{member}</Typography>
-                </Box>
-              </Grid>
-            </>
+            <Grid item key={member} md={6} xs={12}>
+              <Box alignItems='center' display='flex' flexWrap='wrap'>
+                <PersonIcon className={classes.icons} />
+                <Typography variant='subtitle1'>{member}</Typography>
+              </Box>
+            </Grid>
           );
         })}
       </Grid>

--- a/src/containers/Pages/specials/Index/MembersCard.tsx
+++ b/src/containers/Pages/specials/Index/MembersCard.tsx
@@ -1,11 +1,15 @@
 import Typography from '@material-ui/core/Typography';
 import Box from '@material-ui/core/Box';
 import Grid from '@material-ui/core/Grid';
+import Skeleton from '@material-ui/lab/Skeleton';
 import { makeStyles } from '@material-ui/core/styles';
 import Paper from 'components/layout/Paper';
 import PersonIcon from '@material-ui/icons/Person';
+import { useMemberships } from 'api/hooks/Membership';
+import StarIcon from '@material-ui/icons/Star';
+import { Groups } from 'types/Enums';
 export type MembersCardProps = {
-  members: string[];
+  slug: Groups;
 };
 
 const useStyles = makeStyles((theme) => ({
@@ -14,24 +18,53 @@ const useStyles = makeStyles((theme) => ({
   },
 }));
 
-const MembersCard = ({ members }: MembersCardProps) => {
+const MembersCard = ({ slug }: MembersCardProps) => {
+  const { data } = useMemberships(slug.toLowerCase());
+  const leader = data?.find((member) => member.membership_type === 'LEADER');
+  const members = data?.filter((element) => element.membership_type === 'MEMBER').map((member) => `${member.user.first_name} ${member.user.last_name}`);
   const classes = useStyles();
+
+  if (!members) {
+    return <Skeleton height='100px' variant='rect' />;
+  }
+
+  if (members.length === 0 && !leader) {
+    return null;
+  }
+
   return (
     <Paper>
       <Grid container spacing={2}>
-        <Grid item xs={12}>
-          <Box alignItems='center' display='flex' flexWrap='wrap'>
-            <Typography variant='h2'>Medlemmer</Typography>
-          </Box>
-        </Grid>
-        {members.map((member) => {
-          return (
-            <Grid item key={member} md={6} xs={12}>
+        {leader && (
+          <>
+            <Grid item xs={12}>
+              <Typography variant='subtitle1'>
+                <b>Leder:</b>
+              </Typography>
               <Box alignItems='center' display='flex' flexWrap='wrap'>
-                <PersonIcon className={classes.icons} />
-                <Typography variant='subtitle1'>{member}</Typography>
+                <StarIcon className={classes.icons} />
+                <Typography variant='subtitle1'>{`${leader?.user.first_name} ${leader?.user.last_name}`}</Typography>
               </Box>
             </Grid>
+          </>
+        )}
+        {members.length > 0 && (
+          <Grid item xs={12}>
+            <Typography variant='subtitle1'>
+              <b>Medlemmer:</b>
+            </Typography>
+          </Grid>
+        )}
+        {members.map((member) => {
+          return (
+            <>
+              <Grid item key={member} md={6} xs={12}>
+                <Box alignItems='center' display='flex' flexWrap='wrap'>
+                  <PersonIcon className={classes.icons} />
+                  <Typography variant='subtitle1'>{member}</Typography>
+                </Box>
+              </Grid>
+            </>
           );
         })}
       </Grid>

--- a/src/containers/Pages/specials/Index/index.tsx
+++ b/src/containers/Pages/specials/Index/index.tsx
@@ -1,18 +1,15 @@
 import ErrorCard from 'containers/Pages/specials/Index/ErrorCard';
 import WorkDoneCard from 'containers/Pages/specials/Index/WorkDoneCard';
 import MembersCard from 'containers/Pages/specials/Index/MembersCard';
-import { useMemberships } from 'api/hooks/Membership';
 import { Groups } from 'types/Enums';
 
 const AboutIndex = () => {
-  const { data } = useMemberships(Groups.INDEX.toLowerCase());
-  const members = data?.map((member) => `${member.user.first_name} ${member.user.last_name}`);
   return (
     <>
       <WorkDoneCard changelogURL={'https://raw.githubusercontent.com/tihlde/Kvark/dev/CHANGELOG.md'} title={'Hva har vi gjort i frontend?'} />
       <WorkDoneCard changelogURL={'https://raw.githubusercontent.com/tihlde/Lepton/dev/CHANGELOG.md'} title={'Hva har vi gjort i backend?'} />
       <ErrorCard />
-      <MembersCard members={members || []} />
+      <MembersCard slug={Groups.INDEX} />
     </>
   );
 };

--- a/src/types/Enums.tsx
+++ b/src/types/Enums.tsx
@@ -40,6 +40,8 @@ export enum Groups {
   INDEX = 'Index',
   PROMO = 'Promo',
   NOK = 'NoK',
+  SOSIALEN = 'Sosialen',
+  DRIFT = 'Drift',
 }
 
 export enum FormType {

--- a/src/types/Types.tsx
+++ b/src/types/Types.tsx
@@ -248,4 +248,5 @@ export interface PageTree {
 }
 export interface Membership {
   user: User;
+  membership_type: 'LEADER' | 'MEMBER';
 }


### PR DESCRIPTION
## Description

Each of the sections under "undergrupper" will now display the members from the database. If there are no leader and no members the member card will not be rendered. It will also display a bit different dependent on whether there is a leader from the database or members (see screenshots). 

Comments/issues/screenshots:

![image](https://user-images.githubusercontent.com/49594236/112689567-c65bee80-8e7a-11eb-95ac-c497a1e79d0a.png)

![image](https://user-images.githubusercontent.com/49594236/112689599-d1168380-8e7a-11eb-8968-6cda2d6b3e77.png)

![image](https://user-images.githubusercontent.com/49594236/112689632-da075500-8e7a-11eb-8583-ebfd2becce28.png)


closes #31 

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [x] The PR includes a `closes #issueID`
- [x] The PR includes a picture showing visual changes
