### PR TITLE
Feat/group admin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 
 - ⚡ **Fjern bilde**. Det er nå mulig å fjerne et bilde som er lagt til arrangementer, nyheter, annonser og sider.
 - ⚡ **Tilgangs-håndtering**. Endret håndtering av tilganger til nytt system hvor brukere får tilganger basert på medlemskap i grupper.
+- ✨ **Gruppe-administrator**. Nå er det mulig for de ulike gruppe-lederne å legge til medlemmer i gruppen.
 
 ## Versjon 1.0.7 (09.04.2021)
 

--- a/src/URLS.tsx
+++ b/src/URLS.tsx
@@ -4,6 +4,10 @@ export const PAGES_URLS = {
   CONTACT_US: 'kontakt-oss/',
   EVENT_RULES: 'annet/arrangementsregler/',
   NEW_STUDENT: 'ny-student/',
+  SOSIALEN: 'tihlde/undergrupper/sosialen/',
+  DRIFT: 'tihlde/undergrupper/drift/',
+  NOK: 'tihlde/undergrupper/nringsliv-og-kurs/',
+  PROMO: 'tihlde/undergrupper/promo/',
 };
 
 export default {
@@ -30,4 +34,5 @@ export default {
   eventAdmin: '/admin/arrangementer/',
   jobpostsAdmin: '/admin/karriere/',
   newsAdmin: '/admin/nyheter/',
+  groups: '/grupper/',
 };

--- a/src/URLS.tsx
+++ b/src/URLS.tsx
@@ -34,5 +34,4 @@ export default {
   eventAdmin: '/admin/arrangementer/',
   jobpostsAdmin: '/admin/karriere/',
   newsAdmin: '/admin/nyheter/',
-  groups: '/grupper/',
 };

--- a/src/api/api.tsx
+++ b/src/api/api.tsx
@@ -28,7 +28,6 @@ import {
   User,
   UserCreate,
   Warning,
-  Group,
 } from 'types/Types';
 
 export default {
@@ -85,9 +84,6 @@ export default {
   getUsers: (filters?: any) => IFetch<PaginationResponse<User>>({ method: 'GET', url: `user/`, data: filters || {} }),
   updateUserData: (userName: string, item: Partial<User>) => IFetch<User>({ method: 'PUT', url: `user/${userName}/`, data: item }),
   activateUser: (userName: string) => IFetch<RequestResponse>({ method: 'POST', url: `activate-user/`, data: { user_id: userName } }),
-
-  // Groups
-  getGroups: () => IFetch<Group[]>({ method: 'GET', url: `group/` }),
 
   // Notifications
   getNotifications: (filters?: any) => IFetch<PaginationResponse<Notification>>({ method: 'GET', url: `notification/`, data: filters || {} }),

--- a/src/api/api.tsx
+++ b/src/api/api.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { IFetch } from 'api/fetch';
-import { Study } from 'types/Enums';
+import { MembershipType, Study } from 'types/Enums';
 import {
   Category,
   Cheatsheet,
@@ -28,6 +28,7 @@ import {
   User,
   UserCreate,
   Warning,
+  Group,
 } from 'types/Types';
 
 export default {
@@ -122,6 +123,16 @@ export default {
 
   //Membership
   getMemberships: (slug: string) => IFetch<Membership[]>({ method: 'GET', url: `group/${slug}/membership/` }),
+  createMembership: (slug: string, userId: string) =>
+    IFetch<Membership>({ method: 'POST', url: `group/${slug}/membership/`, data: { user: { user_id: userId } } }),
+  deleteMembership: (slug: string, userId: string) => IFetch<RequestResponse>({ method: 'DELETE', url: `group/${slug}/membership/${userId}/` }),
+  updateMembership: (slug: string, userId: string, data: { membership_type: MembershipType }) =>
+    IFetch<Membership>({ method: 'PUT', url: `group/${slug}/membership/${userId}/`, data }),
+
+  //Group
+  getGroups: () => IFetch<Group[]>({ method: 'GET', url: `group/` }),
+  getGroup: (slug: string) => IFetch<Group>({ method: 'GET', url: `group/${slug}/` }),
+  updateGroup: (slug: string, data: Group) => IFetch<Group>({ method: 'PUT', url: `group/${slug}/`, data }),
 
   // Pages
   getPageTree: () => IFetch<PageTree>({ method: 'GET', url: `page/tree/` }),

--- a/src/api/hooks/Group.tsx
+++ b/src/api/hooks/Group.tsx
@@ -1,10 +1,22 @@
+import { useMutation, UseMutationResult, useQuery, useQueryClient } from 'react-query';
 import API from 'api/api';
-import { useQuery } from 'react-query';
 import { Group, RequestResponse } from 'types/Types';
 
-export const QUERY_KEY_GROUPS = 'groups';
+export const GROUPS_QUERY_KEY = 'groups';
+export const useGroup = (slug: string) => {
+  return useQuery<Group, RequestResponse>([GROUPS_QUERY_KEY, slug], () => API.getGroup(slug));
+};
+export const useUpdateGroup = (): UseMutationResult<Group, RequestResponse, Group, unknown> => {
+  const queryClient = useQueryClient();
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return useMutation((group) => API.updateGroup(group.slug, group), {
+    onSuccess: (data) => {
+      queryClient.invalidateQueries([GROUPS_QUERY_KEY, data.slug]);
+      queryClient.setQueryData([GROUPS_QUERY_KEY, data.slug], data);
+    },
+  });
+};
+
 export const useGroups = () => {
-  return useQuery<Group[], RequestResponse>([QUERY_KEY_GROUPS], () => API.getGroups());
+  return useQuery<Group[], RequestResponse>([GROUPS_QUERY_KEY], () => API.getGroups());
 };

--- a/src/api/hooks/Membership.tsx
+++ b/src/api/hooks/Membership.tsx
@@ -1,8 +1,40 @@
-import { useQuery } from 'react-query';
+import { useMutation, UseMutationResult, useQuery, useQueryClient } from 'react-query';
 import API from 'api/api';
-import { Membership } from 'types/Types';
+import { Membership, RequestResponse } from 'types/Types';
+import { MembershipType } from 'types/Enums';
+import { GROUPS_QUERY_KEY } from 'api/hooks/Group';
 
-const QUERY_KEY = 'membership';
+export const QUERY_KEY = 'membership';
 export const useMemberships = (slug: string) => {
   return useQuery<Membership[]>([QUERY_KEY, slug], () => API.getMemberships(slug));
+};
+
+export const useCreateMembership = (): UseMutationResult<Membership, RequestResponse, { groupSlug: string; userId: string }, unknown> => {
+  const queryClient = useQueryClient();
+  return useMutation(({ groupSlug, userId }) => API.createMembership(groupSlug, userId), {
+    onSuccess: (data) => {
+      queryClient.invalidateQueries([QUERY_KEY, data.group.slug]);
+      queryClient.setQueryData([QUERY_KEY, data.group.slug], (cache) => [...Array(cache), data]);
+    },
+  });
+};
+
+export const useDeleteMembership = (slug: string, user_id: string): UseMutationResult<RequestResponse, RequestResponse, unknown, unknown> => {
+  const queryClient = useQueryClient();
+
+  return useMutation(() => API.deleteMembership(slug, user_id), {
+    onSuccess: () => {
+      queryClient.invalidateQueries([QUERY_KEY, slug]);
+    },
+  });
+};
+
+export const useUpdateMembership = (slug: string, user_id: string): UseMutationResult<Membership, RequestResponse, MembershipType, unknown> => {
+  const queryClient = useQueryClient();
+  return useMutation((membership_type) => API.updateMembership(slug, user_id, { membership_type }), {
+    onSuccess: (data) => {
+      queryClient.invalidateQueries([QUERY_KEY, slug]);
+      queryClient.setQueryData([GROUPS_QUERY_KEY, slug], data.group);
+    },
+  });
 };

--- a/src/containers/GroupAdmin/components/AddMemberModal.tsx
+++ b/src/containers/GroupAdmin/components/AddMemberModal.tsx
@@ -1,0 +1,77 @@
+import { TextField, ListItemText } from '@material-ui/core';
+import useSnackbar from 'api/hooks/Snackbar';
+import { Controller, useForm } from 'react-hook-form';
+import { useUsers } from 'api/hooks/User';
+import { useMemo, useState } from 'react';
+import { Autocomplete } from '@material-ui/lab';
+import { getUserClass, getUserStudyShort } from 'utils';
+import { useCreateMembership } from 'api/hooks/Membership';
+import Dialog from 'components/layout/Dialog';
+
+type AddMemberModalProps = {
+  modalIsOpen: boolean;
+  handleClose: () => void;
+  groupSlug: string;
+};
+
+const AddMemberModal = ({ modalIsOpen, handleClose, groupSlug }: AddMemberModalProps) => {
+  const { control, handleSubmit } = useForm();
+  const showSnackbar = useSnackbar();
+  const createMembership = useCreateMembership();
+
+  const [search, setSearch] = useState('');
+  const filters = useMemo(() => {
+    const filters: Record<string, unknown> = {};
+    if (search) {
+      filters.search = search;
+    }
+    return filters;
+  }, [search]);
+
+  const onSubmit = handleSubmit((formData) => {
+    createMembership.mutate(
+      { groupSlug: groupSlug, userId: formData.user.user_id },
+      {
+        onSuccess: () => {
+          showSnackbar('Medlem lagt til', 'success');
+          handleClose();
+        },
+        onError: (e) => {
+          showSnackbar(e.detail, 'error');
+        },
+      },
+    );
+  });
+
+  const { data } = useUsers(filters);
+
+  const options = data?.pages.map((page) => page.results);
+
+  return (
+    <Dialog confirmText='Legg til medlem' onCancel={handleClose} onClose={handleClose} onConfirm={onSubmit} open={modalIsOpen} titleText='Legg til medlem'>
+      <form onSubmit={onSubmit}>
+        <Controller
+          control={control}
+          name='user'
+          render={({ onChange }) => (
+            <Autocomplete
+              getOptionLabel={(option) => `${option.first_name} ${option.last_name}`}
+              noOptionsText={'Fant ingen medlemmer'}
+              onChange={(_, user) => onChange(user)}
+              options={options?.[0] || []}
+              renderInput={(params) => <TextField {...params} label='Medlem' onChange={(e) => setSearch(e.target.value)} variant='outlined' />}
+              renderOption={(option) => (
+                <ListItemText
+                  primary={`${option.first_name} ${option.last_name}`}
+                  secondary={`${getUserClass(option.user_class)} ${getUserStudyShort(option.user_study)}`}
+                />
+              )}
+            />
+          )}
+        />
+      </form>
+    </Dialog>
+  );
+};
+
+export default AddMemberModal;

--- a/src/containers/GroupAdmin/components/MemberListItem.tsx
+++ b/src/containers/GroupAdmin/components/MemberListItem.tsx
@@ -1,0 +1,106 @@
+import { Box, Button, Collapse, Divider, ListItem, ListItemText, makeStyles } from '@material-ui/core';
+import Paper from 'components/layout/Paper';
+import { useState } from 'react';
+import ExpandMoreIcon from '@material-ui/icons/ExpandMoreRounded';
+import ExpandLessIcon from '@material-ui/icons/ExpandLessRounded';
+import { User } from 'types/Types';
+import { getUserClass, getUserStudyShort } from 'utils';
+import HighlightOffIcon from '@material-ui/icons/HighlightOff';
+import StarIcon from '@material-ui/icons/Star';
+import classNames from 'classnames';
+import { useDeleteMembership, useUpdateMembership } from 'api/hooks/Membership';
+import useSnackbar from 'api/hooks/Snackbar';
+import { MembershipType } from 'types/Enums';
+import Dialog from 'components/layout/Dialog';
+
+const useStyles = makeStyles((theme) => ({
+  root: {
+    marginBottom: theme.spacing(2),
+  },
+  button: {
+    textTransform: 'none',
+  },
+  gutterBottom: {
+    marginBottom: theme.spacing(2),
+  },
+}));
+
+type MemberListItemProps = {
+  user: User;
+  slug: string;
+};
+
+const MemberListItem = ({ slug, user }: MemberListItemProps) => {
+  const classes = useStyles();
+  const [expanded, setExpanded] = useState(false);
+  const deleteMembership = useDeleteMembership(slug, user.user_id);
+  const updateMembership = useUpdateMembership(slug, user.user_id);
+  const showSnackbar = useSnackbar();
+  const [confirmDeleteModal, setConfirmDeleteModal] = useState(false);
+  const [confirmSwitchLeader, setConfirmSwitchLeader] = useState(false);
+  const handleClose = () => {
+    setConfirmDeleteModal(false);
+    setConfirmSwitchLeader(false);
+  };
+
+  const removeMemberFromGroup = () => {
+    deleteMembership.mutate(null, {
+      onSuccess: (data) => {
+        showSnackbar(data.detail, 'success');
+      },
+      onError: (e) => {
+        showSnackbar(e.detail, 'error');
+      },
+    });
+  };
+
+  const promoteUserToLeader = () => {
+    updateMembership.mutate(MembershipType.LEADER, {
+      onSuccess: () => {
+        showSnackbar('Brukeren ble promotert til leder', 'success');
+      },
+      onError: (e) => {
+        showSnackbar(e.detail, 'error');
+      },
+    });
+  };
+  return (
+    <Paper className={classes.root} noPadding>
+      <Dialog
+        onClose={handleClose}
+        onConfirm={removeMemberFromGroup}
+        open={confirmDeleteModal}
+        titleText={`Fjern ${user.first_name} ${user.last_name} fra gruppen?`}
+      />
+      <Dialog
+        onClose={handleClose}
+        onConfirm={promoteUserToLeader}
+        open={confirmSwitchLeader}
+        titleText={`Promoter ${user.first_name} ${user.last_name} til leder?`}
+      />
+      <ListItem button onClick={() => setExpanded((prev) => !prev)}>
+        <ListItemText primary={`${user.first_name} ${user.last_name}`} secondary={`${getUserClass(user.user_class)}. ${getUserStudyShort(user.user_study)}`} />
+        {expanded ? <ExpandLessIcon /> : <ExpandMoreIcon />}
+      </ListItem>
+      <Collapse in={expanded}>
+        <Divider />
+        <Box display='flex' flexDirection='column' padding={1}>
+          <Button
+            className={classNames(classes.button, classes.gutterBottom)}
+            fullWidth
+            onClick={() => setConfirmDeleteModal(true)}
+            size='large'
+            startIcon={<HighlightOffIcon />}
+            variant='outlined'>
+            Fjern medlem
+          </Button>
+          <Button className={classes.button} fullWidth onClick={() => setConfirmSwitchLeader(true)} size='large' startIcon={<StarIcon />} variant='outlined'>
+            Promoter til leder
+          </Button>
+        </Box>
+      </Collapse>
+    </Paper>
+  );
+};
+
+export default MemberListItem;

--- a/src/containers/GroupAdmin/components/UpdateGroupModal.tsx
+++ b/src/containers/GroupAdmin/components/UpdateGroupModal.tsx
@@ -1,0 +1,48 @@
+import { useUpdateGroup } from 'api/hooks/Group';
+import useSnackbar from 'api/hooks/Snackbar';
+import TextField from 'components/inputs/TextField';
+import Dialog from 'components/layout/Dialog';
+import { useForm } from 'react-hook-form';
+import { Group } from 'types/Types';
+type UpdateGroupModalProps = {
+  modalIsOpen: boolean;
+  handleClose: () => void;
+  group: Group;
+};
+
+const UpdateGroupModal = ({ modalIsOpen, handleClose, group }: UpdateGroupModalProps) => {
+  const { register, errors, handleSubmit } = useForm();
+  const updateGroup = useUpdateGroup();
+  const showSnackbar = useSnackbar();
+
+  const onSubmit = handleSubmit((formData: Group) => {
+    const data = { ...group, name: formData.name, description: formData.description, contact_email: formData.contact_email };
+    updateGroup.mutate(data, {
+      onSuccess: () => {
+        handleClose();
+        showSnackbar('Gruppe oppdatert', 'success');
+      },
+      onError: (e) => {
+        showSnackbar(e.detail, 'error');
+      },
+    });
+  });
+  return (
+    <Dialog confirmText='Oppdater gruppe' onClose={handleClose} onConfirm={onSubmit} open={modalIsOpen} titleText={'Oppdater gruppe'}>
+      <TextField defaultValue={group.name} errors={errors} label='Gruppenavn' name='name' register={register} required />
+      <TextField
+        defaultValue={group.description}
+        errors={errors}
+        label='Gruppebeskrivelse'
+        multiline
+        name='description'
+        register={register}
+        required
+        rows={6}
+      />
+      <TextField defaultValue={group.contact_email} errors={errors} label='Kontakt e-post' name='contact_email' register={register} />
+    </Dialog>
+  );
+};
+
+export default UpdateGroupModal;

--- a/src/containers/GroupAdmin/index.tsx
+++ b/src/containers/GroupAdmin/index.tsx
@@ -1,0 +1,102 @@
+import { Button, makeStyles, Typography } from '@material-ui/core';
+import Banner from 'components/layout/Banner';
+import Paper from 'components/layout/Paper';
+import { Skeleton } from '@material-ui/lab';
+import Navigation from 'components/navigation/Navigation';
+import { Helmet } from 'react-helmet';
+import { useParams } from 'react-router-dom';
+import EditIcon from '@material-ui/icons/Edit';
+import AddIcon from '@material-ui/icons/Add';
+import Http404 from 'containers/Http404';
+import { useGroup } from 'api/hooks/Group';
+import { useMemberships } from 'api/hooks/Membership';
+import { useState } from 'react';
+import UpdateGroupModal from 'containers/GroupAdmin/components/UpdateGroupModal';
+import MemberListItem from 'containers/GroupAdmin/components/MemberListItem';
+import AddMemberModal from './components/AddMemberModal';
+import MembersCard from 'containers/Pages/specials/Index/MembersCard';
+
+const useStyles = makeStyles((theme) => ({
+  gutterBottom: {
+    marginBottom: theme.spacing(2),
+  },
+  button: {
+    textTransform: 'none',
+  },
+}));
+
+const Group = () => {
+  const classes = useStyles();
+  const { slug: slugParameter } = useParams();
+  const slug = slugParameter.toLowerCase();
+
+  const [updateGroupModalIsOpen, setUpdateGroupModalIsOpen] = useState(false);
+  const [addMemberModalIsOpen, setAddMemberModalIsOpen] = useState(false);
+
+  const { data, isLoading: isLoadingGroups, isError } = useGroup(slug);
+
+  const hasWriteAcccess = Boolean(data?.permissions.write);
+
+  const { data: membersData, isLoading: isLoadingMembers } = useMemberships(slug);
+  if (isError) {
+    return <Http404 />;
+  }
+
+  const members = membersData?.filter((memberObject) => memberObject.membership_type === 'MEMBER').map((member) => member.user);
+  const membersSorted = members?.sort((a, b) => `${a.first_name} ${a.last_name}`.localeCompare(`${b.first_name} ${b.last_name}`));
+  return (
+    <Navigation banner={<Banner title={data?.name} />} fancyNavbar>
+      <Helmet>
+        <title>{data?.name}</title>
+      </Helmet>
+      {isLoadingGroups || isLoadingMembers || !data || !membersSorted ? (
+        <>
+          <Paper className={classes.gutterBottom}>
+            <Skeleton height='100px' variant='rect' />
+          </Paper>
+          <Paper>
+            <Skeleton height='200px' variant='rect' />
+          </Paper>
+        </>
+      ) : (
+        <>
+          <UpdateGroupModal group={data} handleClose={() => setUpdateGroupModalIsOpen(false)} modalIsOpen={updateGroupModalIsOpen} />
+          <AddMemberModal groupSlug={slug} handleClose={() => setAddMemberModalIsOpen(false)} modalIsOpen={addMemberModalIsOpen} />
+          <Paper className={classes.gutterBottom}>
+            <Typography gutterBottom variant='subtitle1'>
+              {data?.description}
+            </Typography>
+            <Typography gutterBottom variant='subtitle1'>
+              <b>Kontakt: </b> {data?.contact_email}
+            </Typography>
+            {hasWriteAcccess && (
+              <Button color='primary' onClick={() => setUpdateGroupModalIsOpen(true)} startIcon={<EditIcon />} variant='contained'>
+                Rediger gruppe
+              </Button>
+            )}
+          </Paper>
+          {hasWriteAcccess ? (
+            <Paper className={classes.gutterBottom}>
+              {data?.leader && (
+                <Typography gutterBottom variant='subtitle1'>
+                  <b>Leder: </b> {data.leader.first_name} {data.leader.last_name} 👑
+                </Typography>
+              )}
+              <Typography gutterBottom variant='subtitle1'>
+                <b>Medlemmer:</b>
+              </Typography>
+              {membersSorted && membersSorted.map((member) => <MemberListItem key={member.user_id} slug={slug} user={member} />)}
+              <Button color='primary' onClick={() => setAddMemberModalIsOpen(true)} startIcon={<AddIcon />} variant='contained'>
+                Legg til medlem
+              </Button>
+            </Paper>
+          ) : (
+            <MembersCard slug={slug} />
+          )}
+        </>
+      )}
+    </Navigation>
+  );
+};
+
+export default Group;

--- a/src/containers/GroupAdmin/index.tsx
+++ b/src/containers/GroupAdmin/index.tsx
@@ -85,7 +85,9 @@ const Group = () => {
               <Typography gutterBottom variant='subtitle1'>
                 <b>Medlemmer:</b>
               </Typography>
-              {membersSorted && membersSorted.map((member) => <MemberListItem key={member.user_id} slug={slug} user={member} />)}
+              {membersSorted.map((member) => (
+                <MemberListItem key={member.user_id} slug={slug} user={member} />
+              ))}
               <Button color='primary' onClick={() => setAddMemberModalIsOpen(true)} startIcon={<AddIcon />} variant='contained'>
                 Legg til medlem
               </Button>

--- a/src/containers/GroupAdmin/index.tsx
+++ b/src/containers/GroupAdmin/index.tsx
@@ -66,9 +66,11 @@ const Group = () => {
             <Typography gutterBottom variant='subtitle1'>
               {data?.description}
             </Typography>
-            <Typography gutterBottom variant='subtitle1'>
-              <b>Kontakt: </b> {data?.contact_email}
-            </Typography>
+            {data?.contact_email && (
+              <Typography gutterBottom variant='subtitle1'>
+                <b>Kontakt: </b> {data?.contact_email}
+              </Typography>
+            )}
             {hasWriteAcccess && (
               <Button color='primary' onClick={() => setUpdateGroupModalIsOpen(true)} startIcon={<EditIcon />} variant='contained'>
                 Rediger gruppe

--- a/src/containers/GroupOverview/components/GroupItem.tsx
+++ b/src/containers/GroupOverview/components/GroupItem.tsx
@@ -49,7 +49,7 @@ const GroupItem = ({ group }: GroupItemProps) => {
   const navigate = useNavigate();
 
   return (
-    <ButtonBase className={classes.container} onClick={() => navigate(`/grupper/${group.slug}`)}>
+    <ButtonBase className={classes.container} onClick={() => navigate(`/grupper/${group.slug}/`)}>
       <Typography className={classes.group} variant='h3'>
         {group.name}
       </Typography>

--- a/src/containers/Pages/index.tsx
+++ b/src/containers/Pages/index.tsx
@@ -19,6 +19,8 @@ import MarkdownRenderer from 'components/miscellaneous/MarkdownRenderer';
 import PagesAdmin from 'containers/Pages/components/PagesAdmin';
 import PagesList from 'containers/Pages/components/PagesList';
 import ShareButton from 'components/miscellaneous/ShareButton';
+import MembersCard from './specials/Index/MembersCard';
+import { Groups } from 'types/Enums';
 
 const Index = lazy(() => import('containers/Pages/specials/Index'));
 
@@ -91,6 +93,14 @@ const Pages = () => {
 
   const SpecialContent = () => {
     switch (path) {
+      case PAGES_URLS.SOSIALEN:
+        return <MembersCard slug={Groups.SOSIALEN} />;
+      case PAGES_URLS.DRIFT:
+        return <MembersCard slug={Groups.DRIFT} />;
+      case PAGES_URLS.NOK:
+        return <MembersCard slug={Groups.NOK} />;
+      case PAGES_URLS.PROMO:
+        return <MembersCard slug={Groups.PROMO} />;
       case PAGES_URLS.ABOUT_INDEX:
         return <Index />;
       default:

--- a/src/containers/Pages/specials/Index/MembersCard.tsx
+++ b/src/containers/Pages/specials/Index/MembersCard.tsx
@@ -1,11 +1,16 @@
 import Typography from '@material-ui/core/Typography';
 import Box from '@material-ui/core/Box';
 import Grid from '@material-ui/core/Grid';
+import Skeleton from '@material-ui/lab/Skeleton';
 import { makeStyles } from '@material-ui/core/styles';
 import Paper from 'components/layout/Paper';
 import PersonIcon from '@material-ui/icons/Person';
+import { useMemberships } from 'api/hooks/Membership';
+import StarIcon from '@material-ui/icons/Star';
+import { sortBy } from 'lodash';
+
 export type MembersCardProps = {
-  members: string[];
+  slug: string;
 };
 
 const useStyles = makeStyles((theme) => ({
@@ -14,22 +19,52 @@ const useStyles = makeStyles((theme) => ({
   },
 }));
 
-const MembersCard = ({ members }: MembersCardProps) => {
+const MembersCard = ({ slug }: MembersCardProps) => {
+  const { data, isLoading } = useMemberships(slug.toLowerCase());
+  const leader = data?.find((member) => member.membership_type === 'LEADER');
+  const members = data?.filter((element) => element.membership_type === 'MEMBER');
+  const membersSorted = sortBy(members, ['user.first_name', 'user.last_name']);
   const classes = useStyles();
+
+  if (isLoading) {
+    return (
+      <Paper>
+        <Skeleton height='100px' variant='rect' />
+      </Paper>
+    );
+  }
+
+  if (!membersSorted?.length && !leader) {
+    return null;
+  }
+
   return (
     <Paper>
       <Grid container spacing={2}>
-        <Grid item xs={12}>
-          <Box alignItems='center' display='flex' flexWrap='wrap'>
-            <Typography variant='h2'>Medlemmer</Typography>
-          </Box>
-        </Grid>
-        {members.map((member) => {
+        {leader && (
+          <Grid item xs={12}>
+            <Typography variant='subtitle1'>
+              <b>Leder:</b>
+            </Typography>
+            <Box alignItems='center' display='flex' flexWrap='wrap'>
+              <StarIcon className={classes.icons} />
+              <Typography variant='subtitle1'>{`${leader?.user.first_name} ${leader?.user.last_name}`}</Typography>
+            </Box>
+          </Grid>
+        )}
+        {Boolean(membersSorted.length) && (
+          <Grid item xs={12}>
+            <Typography variant='subtitle1'>
+              <b>Medlemmer:</b>
+            </Typography>
+          </Grid>
+        )}
+        {membersSorted?.map((member) => {
           return (
-            <Grid item key={member} md={6} xs={12}>
+            <Grid item key={member.user.user_id} md={6} xs={12}>
               <Box alignItems='center' display='flex' flexWrap='wrap'>
                 <PersonIcon className={classes.icons} />
-                <Typography variant='subtitle1'>{member}</Typography>
+                <Typography variant='subtitle1'>{`${member.user.first_name} ${member.user.last_name}`}</Typography>
               </Box>
             </Grid>
           );

--- a/src/containers/Pages/specials/Index/MembersCard.tsx
+++ b/src/containers/Pages/specials/Index/MembersCard.tsx
@@ -7,7 +7,6 @@ import Paper from 'components/layout/Paper';
 import PersonIcon from '@material-ui/icons/Person';
 import { useMemberships } from 'api/hooks/Membership';
 import StarIcon from '@material-ui/icons/Star';
-import { sortBy } from 'lodash';
 
 export type MembersCardProps = {
   slug: string;
@@ -23,7 +22,8 @@ const MembersCard = ({ slug }: MembersCardProps) => {
   const { data, isLoading } = useMemberships(slug.toLowerCase());
   const leader = data?.find((member) => member.membership_type === 'LEADER');
   const members = data?.filter((element) => element.membership_type === 'MEMBER');
-  const membersSorted = sortBy(members, ['user.first_name', 'user.last_name']);
+  const membersSorted = members?.sort((a, b) => `${a.user.first_name} ${a.user.last_name}`.localeCompare(`${b.user.first_name} ${b.user.last_name}`));
+
   const classes = useStyles();
 
   if (isLoading) {
@@ -52,7 +52,7 @@ const MembersCard = ({ slug }: MembersCardProps) => {
             </Box>
           </Grid>
         )}
-        {Boolean(membersSorted.length) && (
+        {Boolean(membersSorted?.length) && (
           <Grid item xs={12}>
             <Typography variant='subtitle1'>
               <b>Medlemmer:</b>

--- a/src/containers/Pages/specials/Index/index.tsx
+++ b/src/containers/Pages/specials/Index/index.tsx
@@ -1,17 +1,15 @@
 import ErrorCard from 'containers/Pages/specials/Index/ErrorCard';
 import WorkDoneCard from 'containers/Pages/specials/Index/WorkDoneCard';
 import MembersCard from 'containers/Pages/specials/Index/MembersCard';
-import { useMemberships } from 'api/hooks/Membership';
+import { Groups } from 'types/Enums';
 
 const AboutIndex = () => {
-  const { data } = useMemberships('index');
-  const members = data?.map((member) => `${member.user.first_name} ${member.user.last_name}`);
   return (
     <>
-      <WorkDoneCard changelogURL={'https://raw.githubusercontent.com/tihlde/Kvark/dev/CHANGELOG.md'} title={'Hva har vi gjort i frontend?'} />
-      <WorkDoneCard changelogURL={'https://raw.githubusercontent.com/tihlde/Lepton/dev/CHANGELOG.md'} title={'Hva har vi gjort i backend?'} />
+      <WorkDoneCard changelogURL={'https://raw.githubusercontent.com/tihlde/Kvark/master/CHANGELOG.md'} title={'Hva har vi gjort i frontend?'} />
+      <WorkDoneCard changelogURL={'https://raw.githubusercontent.com/tihlde/Lepton/master/CHANGELOG.md'} title={'Hva har vi gjort i backend?'} />
       <ErrorCard />
-      <MembersCard members={members || []} />
+      <MembersCard slug={Groups.INDEX} />
     </>
   );
 };

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -42,6 +42,7 @@ const NewsAdministration = lazy(() => import('containers/NewsAdministration'));
 const ShortLinks = lazy(() => import('containers/ShortLinks'));
 const SignUp = lazy(() => import('containers/SignUp'));
 const UserAdmin = lazy(() => import('containers/UserAdmin'));
+import GroupAdmin from 'containers/GroupAdmin/index';
 
 type AuthRouteProps = {
   apps?: Array<PermissionApp>;
@@ -143,6 +144,8 @@ const AppRoutes = () => {
         <Route element={<NewsAdministration />} path=':newsId/' />
         <Route element={<NewsAdministration />} path='' />
       </AuthRoute>
+
+      <Route element={<GroupAdmin />} path={`${URLS.groups}:slug/`} />
 
       <Route element={<LogIn />} path={URLS.login} />
       <Route element={<ForgotPassword />} path={URLS.forgotPassword} />

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -42,7 +42,7 @@ const NewsAdministration = lazy(() => import('containers/NewsAdministration'));
 const ShortLinks = lazy(() => import('containers/ShortLinks'));
 const SignUp = lazy(() => import('containers/SignUp'));
 const UserAdmin = lazy(() => import('containers/UserAdmin'));
-import GroupAdmin from 'containers/GroupAdmin/index';
+const GroupAdmin = lazy(() => import('containers/GroupAdmin/index'));
 
 type AuthRouteProps = {
   apps?: Array<PermissionApp>;

--- a/src/types/Enums.tsx
+++ b/src/types/Enums.tsx
@@ -44,6 +44,14 @@ export enum PermissionApp {
   PAGE = 'page',
   USER = 'user',
 }
+export enum Groups {
+  HS = 'HS',
+  INDEX = 'Index',
+  PROMO = 'Promo',
+  NOK = 'NoK',
+  SOSIALEN = 'Sosialen',
+  DRIFT = 'Drift',
+}
 
 export enum FormType {
   SURVEY = 'SURVEY',
@@ -64,4 +72,8 @@ export enum GroupTypes {
   BOARD = 'BOARD',
   COMMITTEE = 'COMMITTEE',
   SUBGROUP = 'SUBGROUP',
+}
+export enum MembershipType {
+  LEADER = 'LEADER',
+  MEMBER = 'MEMBER',
 }

--- a/src/types/Types.tsx
+++ b/src/types/Types.tsx
@@ -1,4 +1,15 @@
-import { FormFieldType, FormResourceType, FormType, PermissionApp, WarningType, Study, CheatsheetType, UserClass, UserStudy } from 'types/Enums';
+import {
+  FormFieldType,
+  FormResourceType,
+  FormType,
+  MembershipType,
+  PermissionApp,
+  WarningType,
+  Study,
+  CheatsheetType,
+  UserClass,
+  UserStudy,
+} from 'types/Enums';
 
 export interface Warning {
   created_at: string;
@@ -253,6 +264,17 @@ export interface PageTree {
 }
 export interface Membership {
   user: User;
+  membership_type: MembershipType;
+  group: Group;
+}
+export interface Group {
+  name: string;
+  slug: string;
+  description: string;
+  contact_email: string;
+  type: string;
+  leader: User;
+  permissions: Permissions;
 }
 
 export interface Group {

--- a/src/types/Types.tsx
+++ b/src/types/Types.tsx
@@ -276,12 +276,3 @@ export interface Group {
   leader: User;
   permissions: Permissions;
 }
-
-export interface Group {
-  name: string;
-  slug: string;
-  description: string;
-  contact_email: string;
-  type: string;
-  leader: Pick<User, 'user_id' | 'first_name' | 'last_name'>;
-}


### PR DESCRIPTION
## Description

Det er nå mulig å oppdatere de ulike gruppene. Det vil si oppdatere for eksempel beskrivelsen og kontakt-mail. I tillegg kan gruppelederen/Index/HS også legge til medlemmer, fjerne medlemmer og promotere medlemmer til Leder. 

Dersom en bruker ikke har skrive-tilgang til gruppen vil man ikke ha mulighet til å redigere, men man får fortsatt se informasjonen om gruppen. 

**NB: Avhenger av Hermann sin PR fix(group-perm): groups perm fix #80 på Lepton**

Comments/issues/screenshots:

![image](https://user-images.githubusercontent.com/49594236/115356984-7394fe80-a1bc-11eb-9f36-9c559be5df6c.png)

![image](https://user-images.githubusercontent.com/49594236/115357007-7a237600-a1bc-11eb-9cab-c39979a70f3a.png)

![image](https://user-images.githubusercontent.com/49594236/115357028-814a8400-a1bc-11eb-9dfe-4cd5fd3651a9.png)

![image](https://user-images.githubusercontent.com/49594236/115357113-958e8100-a1bc-11eb-81eb-3717e5ef6895.png)


closes #8 

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [x] The PR includes a `closes #issueID`
- [x] The PR includes a picture showing visual changes
