### PR TITLE
refactor(user-avatar): display avatar in participant and useradmin

### DIFF
--- a/src/components/miscellaneous/Avatar.tsx
+++ b/src/components/miscellaneous/Avatar.tsx
@@ -4,7 +4,7 @@ import Skeleton from '@material-ui/lab/Skeleton';
 import { User } from 'types/Types';
 
 type AvatarProps = {
-  user?: User;
+  user?: Pick<User, 'first_name' | 'last_name' | 'image'>;
 } & MuiAvatarProps;
 
 const useStyles = makeStyles({

--- a/src/containers/EventAdministration/components/Participant.tsx
+++ b/src/containers/EventAdministration/components/Participant.tsx
@@ -32,7 +32,7 @@ import Paper from 'components/layout/Paper';
 
 const useStyles = makeStyles((theme: Theme) => ({
   avatar: {
-    marginRight: theme.spacing(1),
+    marginRight: theme.spacing(2),
     [theme.breakpoints.down('sm')]: {
       display: 'none',
     },

--- a/src/containers/EventAdministration/components/Participant.tsx
+++ b/src/containers/EventAdministration/components/Participant.tsx
@@ -11,6 +11,7 @@ import Checkbox from '@material-ui/core/Checkbox';
 import Typography from '@material-ui/core/Typography';
 import Collapse from '@material-ui/core/Collapse';
 import Button from '@material-ui/core/Button';
+import Hidden from '@material-ui/core/Hidden';
 import ListItem from '@material-ui/core/ListItem';
 import ListItemText from '@material-ui/core/ListItemText';
 import ListItemSecondaryAction from '@material-ui/core/ListItemSecondaryAction';
@@ -33,9 +34,6 @@ import Paper from 'components/layout/Paper';
 const useStyles = makeStyles((theme: Theme) => ({
   avatar: {
     marginRight: theme.spacing(2),
-    [theme.breakpoints.down('sm')]: {
-      display: 'none',
-    },
   },
   paper: {
     marginBottom: theme.spacing(1),
@@ -128,7 +126,9 @@ const Participant = ({ registration, eventId }: ParticipantProps) => {
         titleText='Er du sikker?'
       />
       <ListItem button className={classes.wrapper} onClick={() => setExpanded((prev) => !prev)}>
-        <Avatar className={classes.avatar} user={registration.user_info} />
+        <Hidden smDown>
+          <Avatar className={classes.avatar} user={registration.user_info} />
+        </Hidden>
         <ListItemText
           classes={{ secondary: classes.secondaryText }}
           primary={`${registration.user_info.first_name} ${registration.user_info.last_name}`}

--- a/src/containers/EventAdministration/components/Participant.tsx
+++ b/src/containers/EventAdministration/components/Participant.tsx
@@ -26,18 +26,23 @@ import ArrowDownwardIcon from '@material-ui/icons/ArrowDownwardRounded';
 import ArrowUpwardIcon from '@material-ui/icons/ArrowUpwardRounded';
 
 // Project components
+import Avatar from 'components/miscellaneous/Avatar';
 import Dialog from 'components/layout/Dialog';
 import Paper from 'components/layout/Paper';
 
 const useStyles = makeStyles((theme: Theme) => ({
+  avatar: {
+    marginRight: theme.spacing(1),
+    [theme.breakpoints.down('sm')]: {
+      display: 'none',
+    },
+  },
   paper: {
     marginBottom: theme.spacing(1),
     overflow: 'hidden',
     background: theme.palette.background.smoke,
   },
   wrapper: {
-    display: 'grid',
-    gridTemplateColumns: '1fr auto',
     paddingRight: theme.spacing(8),
     alignItems: 'center',
   },
@@ -123,6 +128,7 @@ const Participant = ({ registration, eventId }: ParticipantProps) => {
         titleText='Er du sikker?'
       />
       <ListItem button className={classes.wrapper} onClick={() => setExpanded((prev) => !prev)}>
+        <Avatar className={classes.avatar} user={registration.user_info} />
         <ListItemText
           classes={{ secondary: classes.secondaryText }}
           primary={`${registration.user_info.first_name} ${registration.user_info.last_name}`}

--- a/src/containers/UserAdmin/components/PersonListItem.tsx
+++ b/src/containers/UserAdmin/components/PersonListItem.tsx
@@ -26,7 +26,7 @@ import Paper from 'components/layout/Paper';
 
 const useStyles = makeStyles((theme) => ({
   avatar: {
-    marginRight: theme.spacing(1),
+    marginRight: theme.spacing(2),
   },
   paper: {
     marginBottom: theme.spacing(1),

--- a/src/containers/UserAdmin/components/PersonListItem.tsx
+++ b/src/containers/UserAdmin/components/PersonListItem.tsx
@@ -20,18 +20,20 @@ import ExpandMoreIcon from '@material-ui/icons/ExpandMoreRounded';
 import ExpandLessIcon from '@material-ui/icons/ExpandLessRounded';
 
 // Project components
+import Avatar from 'components/miscellaneous/Avatar';
 import Dialog from 'components/layout/Dialog';
 import Paper from 'components/layout/Paper';
 
 const useStyles = makeStyles((theme) => ({
+  avatar: {
+    marginRight: theme.spacing(1),
+  },
   paper: {
     marginBottom: theme.spacing(1),
     overflow: 'hidden',
     background: theme.palette.background.smoke,
   },
   wrapper: {
-    display: 'grid',
-    gridTemplateColumns: '1fr auto',
     alignItems: 'center',
   },
   secondaryText: {
@@ -74,6 +76,7 @@ const PersonListItem = ({ user }: PersonListItemProps) => {
   return (
     <Paper className={classes.paper} noPadding>
       <ListItem button className={classes.wrapper} onClick={() => setExpanded((prev) => !prev)}>
+        <Avatar className={classes.avatar} user={user} />
         <ListItemText
           classes={{ secondary: classes.secondaryText }}
           primary={`${user.first_name} ${user.last_name}`}


### PR DESCRIPTION
## Description
Viser nå brukerens avatar i deltakerliste og useradmin, se screens

Comments/issues/screenshots:
![image](https://user-images.githubusercontent.com/43957538/115112163-86bd8980-9f84-11eb-9750-588062b132c4.png)
![image](https://user-images.githubusercontent.com/43957538/115112174-8e7d2e00-9f84-11eb-94a1-9ff65134943b.png)


closes #11 

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [x] The PR includes a `closes #issueID`
- [x] The PR includes a picture showing visual changes
