### PR TITLE
feat(users): allow edit of users in useradmin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@
 
 ## Neste versjon
 
+- ✨ **Brukeradmin**. HS og Index kan nå redigere brukere i brukeradmin.
+- ⚡ **Grupper**. Info om grupper kan nå inneholde linker.
+
 ## Versjon 1.0.8 (26.04.2021)
 
 - ⚡ **Fjern bilde**. Det er nå mulig å fjerne et bilde som er lagt til arrangementer, nyheter, annonser og sider.

--- a/src/containers/Profile/components/ProfileSettings.tsx
+++ b/src/containers/Profile/components/ProfileSettings.tsx
@@ -1,12 +1,12 @@
 import { useForm } from 'react-hook-form';
 import { getUserStudyLong, getUserClass } from 'utils';
-import { User } from 'types/Types';
+import { UserList } from 'types/Types';
 import { useUpdateUser } from 'api/hooks/User';
 import { useSnackbar } from 'api/hooks/Snackbar';
 
 // Material-UI
 import { makeStyles } from '@material-ui/core/styles';
-import MenuItem from '@material-ui/core/MenuItem';
+import { MenuItem, Typography } from '@material-ui/core';
 
 // Project components
 import TextField from 'components/inputs/TextField';
@@ -23,15 +23,19 @@ const useStyles = makeStyles((theme) => ({
       gridTemplateColumns: '1fr',
     },
   },
+  gutterTop: {
+    marginTop: theme.spacing(2),
+  },
 }));
 
 export type ProfileSettingsProps = {
-  user: User;
+  user: UserList;
+  isAdmin?: boolean;
 };
 
-type FormData = Pick<User, 'cell' | 'image' | 'gender' | 'allergy' | 'tool' | 'user_class' | 'user_study'>;
+type FormData = Pick<UserList, 'first_name' | 'last_name' | 'email' | 'cell' | 'image' | 'gender' | 'allergy' | 'tool' | 'user_class' | 'user_study'>;
 
-const ProfileSettings = ({ user }: ProfileSettingsProps) => {
+const ProfileSettings = ({ isAdmin, user }: ProfileSettingsProps) => {
   const classes = useStyles();
   const showSnackbar = useSnackbar();
   const updateUser = useUpdateUser();
@@ -40,7 +44,6 @@ const ProfileSettings = ({ user }: ProfileSettingsProps) => {
     if (updateUser.isLoading) {
       return;
     }
-
     updateUser.mutate(
       { userId: user.user_id, user: data },
       {
@@ -59,14 +62,29 @@ const ProfileSettings = ({ user }: ProfileSettingsProps) => {
   } else {
     return (
       <form onSubmit={handleSubmit(updateData)}>
+        {isAdmin && (
+          <div className={classes.selectGrid}>
+            <TextField disabled={updateUser.isLoading} errors={errors} label='Fornavn' name='first_name' register={register} />
+            <TextField disabled={updateUser.isLoading} errors={errors} label='Etternavn' name='last_name' register={register} />
+            <TextField disabled={updateUser.isLoading} errors={errors} label='Epost' name='email' register={register} />
+          </div>
+        )}
         <TextField disabled={updateUser.isLoading} errors={errors} InputProps={{ type: 'number' }} label='Telefon' name='cell' register={register} />
         <ImageUpload errors={errors} label='Velg profilbilde' name='image' ratio={1} register={register} setValue={setValue} watch={watch} />
         <div className={classes.selectGrid}>
-          <Select control={control} disabled errors={errors} label='Studie' name='user_study'>
-            <MenuItem value={user.user_study}>{getUserStudyLong(user.user_study)}</MenuItem>
+          <Select control={control} disabled={!isAdmin} errors={errors} label='Studie' name='user_study'>
+            {[1, 2, 3, 4, 5].map((i) => (
+              <MenuItem key={i} value={i}>
+                {getUserStudyLong(i)}
+              </MenuItem>
+            ))}
           </Select>
-          <Select control={control} disabled errors={errors} label='Klasse' name='user_class'>
-            <MenuItem value={user.user_class}>{getUserClass(user.user_class)}</MenuItem>
+          <Select control={control} disabled={!isAdmin} errors={errors} label='Klasse' name='user_class'>
+            {[1, 2, 3, 4, 5].map((i) => (
+              <MenuItem key={i} value={i}>
+                {getUserClass(i)}
+              </MenuItem>
+            ))}
           </Select>
           <Select control={control} disabled={updateUser.isLoading} errors={errors} label='Kjønn' name='gender'>
             <MenuItem value={1}>Mann</MenuItem>
@@ -79,6 +97,15 @@ const ProfileSettings = ({ user }: ProfileSettingsProps) => {
         <SubmitButton disabled={updateUser.isLoading} errors={errors}>
           Oppdater
         </SubmitButton>
+        {!isAdmin && (
+          <Typography className={classes.gutterTop} variant='body2'>
+            {`Er navn, epost, klasse eller studie er feil? Ta kontakt med oss på `}
+            <a href='https://m.me/tihlde' rel='noopener noreferrer' target='_blank'>
+              Messenger
+            </a>
+            {` eller Slack.`}
+          </Typography>
+        )}
       </form>
     );
   }

--- a/src/containers/UserAdmin/components/PersonListItem.tsx
+++ b/src/containers/UserAdmin/components/PersonListItem.tsx
@@ -6,13 +6,7 @@ import { getUserClass, getUserStudyShort } from 'utils';
 
 // Material UI Components
 import { makeStyles } from '@material-ui/core/styles';
-import Typography from '@material-ui/core/Typography';
-import Collapse from '@material-ui/core/Collapse';
-import Hidden from '@material-ui/core/Hidden';
-import Button from '@material-ui/core/Button';
-import ListItem from '@material-ui/core/ListItem';
-import ListItemText from '@material-ui/core/ListItemText';
-import Divider from '@material-ui/core/Divider';
+import { Typography, Collapse, Hidden, Button, ListItem, ListItemText, Divider } from '@material-ui/core';
 import Skeleton from '@material-ui/lab/Skeleton';
 
 // Icons
@@ -22,6 +16,7 @@ import ExpandLessIcon from '@material-ui/icons/ExpandLessRounded';
 // Project components
 import Avatar from 'components/miscellaneous/Avatar';
 import Paper from 'components/layout/Paper';
+import ProfileSettings from 'containers/Profile/components/ProfileSettings';
 
 const useStyles = makeStyles((theme) => ({
   avatar: {
@@ -75,7 +70,7 @@ const PersonListItem = ({ user, is_TIHLDE_member = true }: PersonListItemProps) 
         />
         {expanded ? <ExpandLessIcon /> : <ExpandMoreIcon />}
       </ListItem>
-      <Collapse in={expanded}>
+      <Collapse in={expanded} mountOnEnter unmountOnExit>
         <Divider />
         <div className={classes.content}>
           <div>
@@ -83,9 +78,10 @@ const PersonListItem = ({ user, is_TIHLDE_member = true }: PersonListItemProps) 
               <Typography variant='subtitle1'>{`${getUserClass(user.user_class)} ${getUserStudyShort(user.user_study)}`}</Typography>
             </Hidden>
             <Typography variant='subtitle1'>{`Brukernavn: ${user.user_id}`}</Typography>
-            <Typography variant='subtitle1'>{`Epost: ${user.email}`}</Typography>
           </div>
-          {!is_TIHLDE_member && (
+          {is_TIHLDE_member ? (
+            <ProfileSettings isAdmin user={user} />
+          ) : (
             <Button color='primary' fullWidth onClick={() => changeStatus()} variant='outlined'>
               Legg til medlem
             </Button>


### PR DESCRIPTION
## Description

Comments/issues/screenshots:
- HS and Index can now edit users in user-admin through an extended version of the profile-settings form.

closes #83 

![image](https://user-images.githubusercontent.com/31009729/117034117-45a6d280-ad03-11eb-968d-dd0e703835a5.png)


## Pull request checklist

Please check if your PR fulfills the following requirements:

- [x] The PR includes a `closes #issueID`
- [x] The PR includes a picture showing visual changes
