### PR TITLE
fix(cache): remove on authing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@
 
 ## Neste versjon
 
+- ⚡ **Cache**. All cache på siden blir nå oppdatert når bruker logger inn eller ut.
+
 ## Versjon 1.0.8 (26.04.2021)
 
 - ⚡ **Fjern bilde**. Det er nå mulig å fjerne et bilde som er lagt til arrangementer, nyheter, annonser og sider.

--- a/src/api/hooks/User.tsx
+++ b/src/api/hooks/User.tsx
@@ -37,7 +37,7 @@ export const useLogin = (): UseMutationResult<LoginRequestResponse, RequestRespo
   return useMutation(({ username, password }) => API.authenticate(username, password), {
     onSuccess: (data) => {
       setCookie(ACCESS_TOKEN, data.token);
-      queryClient.removeQueries(USER_QUERY_KEY);
+      queryClient.removeQueries();
       queryClient.prefetchQuery(USER_QUERY_KEY, () => API.getUserData());
     },
   });
@@ -51,7 +51,7 @@ export const useLogout = () => {
   const queryClient = useQueryClient();
   return () => {
     removeCookie(ACCESS_TOKEN);
-    queryClient.removeQueries(USER_QUERY_KEY);
+    queryClient.removeQueries();
   };
 };
 


### PR DESCRIPTION
## Description

Comments/issues/screenshots:
- All cache on page is reset when a user logs out or in

closes #80 

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [x] The PR includes a `closes #issueID`
- [ ] The PR includes a picture showing visual changes
