### PR TITLE
feat(event): send message to registered users at event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@
 
 ## Neste versjon
 
+- ✨ **Arrangementer**. Arrangør av arrangementer kan sende ut informasjon til påmeldte deltagere via epost/varsler.
+
 ## Versjon 1.1.2 (11.08.2021)
 
 - ✨ **Brukere**. Administratorer kan nå slette nye brukere og legge ved en valgfri begrunnelse.

--- a/src/api/api.tsx
+++ b/src/api/api.tsx
@@ -70,6 +70,8 @@ export default {
   createEvent: (item: EventRequired) => IFetch<Event>({ method: 'POST', url: `${EVENTS_ENDPOINT}/`, data: item }),
   updateEvent: (eventId: number, item: Partial<Event>) => IFetch<Event>({ method: 'PUT', url: `${EVENTS_ENDPOINT}/${String(eventId)}/`, data: item }),
   deleteEvent: (eventId: number) => IFetch<RequestResponse>({ method: 'DELETE', url: `${EVENTS_ENDPOINT}/${String(eventId)}/` }),
+  notifyEventRegistrations: (eventId: number, title: string, message: string) =>
+    IFetch<RequestResponse>({ method: 'POST', url: `${EVENTS_ENDPOINT}/${String(eventId)}/notify/`, data: { title, message } }),
   putAttended: (eventId: number, item: { has_attended: boolean }, userId: string) =>
     IFetch<RequestResponse>({ method: 'PUT', url: `${EVENTS_ENDPOINT}/${String(eventId)}/${EVENT_REGISTRATIONS_ENDPOINT}/${userId}/`, data: item }),
   getRegistration: (eventId: number, userId: string) =>

--- a/src/api/hooks/Event.tsx
+++ b/src/api/hooks/Event.tsx
@@ -50,6 +50,11 @@ export const useDeleteEvent = (eventId: number): UseMutationResult<RequestRespon
   });
 };
 
+export const useNotifyEventRegistrations = (
+  eventId: number,
+): UseMutationResult<RequestResponse, RequestResponse, { title: string; message: string }, unknown> =>
+  useMutation(({ title, message }) => API.notifyEventRegistrations(eventId, title, message));
+
 export const useEventRegistrations = (eventId: number) => {
   return useQuery<Array<Registration>, RequestResponse>([EVENT_QUERY_KEY, eventId, EVENT_QUERY_KEY_REGISTRATION], () => API.getEventRegistrations(eventId));
 };

--- a/src/containers/EventAdministration/components/EventMessageSender.tsx
+++ b/src/containers/EventAdministration/components/EventMessageSender.tsx
@@ -1,0 +1,74 @@
+import { useState } from 'react';
+import { useForm } from 'react-hook-form';
+import { useNotifyEventRegistrations } from 'api/hooks/Event';
+import { useSnackbar } from 'api/hooks/Snackbar';
+
+// Material-UI
+import { Button } from '@material-ui/core';
+import SendIcon from '@material-ui/icons/SendRounded';
+
+// Project components
+import Dialog from 'components/layout/Dialog';
+import SubmitButton from 'components/inputs/SubmitButton';
+import TextField from 'components/inputs/TextField';
+
+export type EventMessageSenderProps = {
+  eventId: number;
+};
+
+type FormValues = {
+  title: string;
+  message: string;
+};
+
+const EventMessageSender = ({ eventId }: EventMessageSenderProps) => {
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const showSnackbar = useSnackbar();
+  const { register, formState, handleSubmit, reset } = useForm<FormValues>();
+  const notify = useNotifyEventRegistrations(eventId);
+
+  const submit = (data: FormValues) => {
+    notify.mutate(
+      { title: data.title, message: data.message },
+      {
+        onSuccess: (data) => {
+          showSnackbar(data.detail, 'success');
+          reset();
+          setDialogOpen(false);
+        },
+        onError: (error) => {
+          showSnackbar(error.detail, 'error');
+        },
+      },
+    );
+  };
+
+  return (
+    <>
+      <Button endIcon={<SendIcon />} fullWidth onClick={() => setDialogOpen(true)} variant='outlined'>
+        Send melding til deltagere
+      </Button>
+      <Dialog
+        contentText='Send en melding på epost og et varsel til de påmeldte deltagerne.'
+        onClose={() => setDialogOpen(false)}
+        open={dialogOpen}
+        titleText='Send melding til påmeldte'>
+        <form onSubmit={handleSubmit(submit)}>
+          <TextField formState={formState} label='Tittel' {...register('title', { required: 'Oppgi en tittel' })} required />
+          <TextField
+            formState={formState}
+            label='Melding'
+            maxRows={10}
+            minRows={3}
+            multiline
+            {...register('message', { required: 'Oppgi en melding' })}
+            required
+          />
+          <SubmitButton formState={formState}>Send melding</SubmitButton>
+        </form>
+      </Dialog>
+    </>
+  );
+};
+
+export default EventMessageSender;

--- a/src/containers/EventAdministration/components/EventParticipants.tsx
+++ b/src/containers/EventAdministration/components/EventParticipants.tsx
@@ -4,13 +4,7 @@ import { useSnackbar } from 'api/hooks/Snackbar';
 
 // Material-UI
 import { makeStyles } from '@material-ui/styles';
-import Typography from '@material-ui/core/Typography';
-import Divider from '@material-ui/core/Divider';
-import FormControlLabel from '@material-ui/core/FormControlLabel';
-import Checkbox from '@material-ui/core/Checkbox';
-import Button from '@material-ui/core/Button';
-import List from '@material-ui/core/List';
-import LinearProgress from '@material-ui/core/LinearProgress';
+import { Typography, Stack, Divider, FormControlLabel, Checkbox, Button, List, LinearProgress } from '@material-ui/core';
 
 // Icons
 import CopyIcon from '@material-ui/icons/FileCopyOutlined';
@@ -18,6 +12,7 @@ import CopyIcon from '@material-ui/icons/FileCopyOutlined';
 // Project
 import Participant from 'containers/EventAdministration/components/Participant';
 import EventStatistics from 'containers/EventAdministration/components/EventStatistics';
+import EventMessageSender from 'containers/EventAdministration/components/EventMessageSender';
 
 const useStyles = makeStyles((theme) => ({
   header: {
@@ -59,9 +54,6 @@ const useStyles = makeStyles((theme) => ({
   },
   lightText: {
     color: theme.palette.text.secondary,
-  },
-  emailButton: {
-    margin: theme.spacing(0, 0, 1),
   },
 }));
 
@@ -160,9 +152,12 @@ const EventParticipants = ({ eventId }: EventParticipantsProps) => {
             </div>
           </>
         )}
-        <Button className={classes.emailButton} endIcon={<CopyIcon />} fullWidth onClick={copyEmails} variant='outlined'>
-          Kopier eposter
-        </Button>
+        <Stack direction={{ xs: 'column', md: 'row' }} spacing={1} sx={{ mb: 1 }}>
+          <Button endIcon={<CopyIcon />} fullWidth onClick={copyEmails} variant='outlined'>
+            Kopier eposter
+          </Button>
+          <EventMessageSender eventId={eventId} />
+        </Stack>
         <div className={classes.flexRow}>
           <Typography className={classes.mainText} variant='h3'>
             Påmeldte ({getAttending.length})


### PR DESCRIPTION
## Description

closes tihlde/Lepton#169

Changes:
Admins på arrangementer kan sende epost/varsel til de påmeldte på et arrangement.

Screenshots:
![image](https://user-images.githubusercontent.com/31009729/131222438-9e3462e2-7ff4-42e3-9798-dab7ae8ab830.png)


## Pull request checklist

Please check if your PR fulfills the following requirements:

- [x] The PR includes a `closes #issueID`
- [x] The PR includes a picture showing visual changes
- [ ] Added Google Analytics tracking if relevant
