### PR TITLE
feat(profile): adding helper text allergies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@
 
 ## Neste versjon
 
+- ✨ **Profil**. Klargjører at brukere skal skrive allergier, og ikke tøys.
+
 ## Versjon 1.2.0 (12.09.2021)
 
 - ✨ **Skjemaer**. Legg til statistikk og svar for spørsmål til arrangementer. Vis i produksjon.

--- a/src/pages/Profile/components/ProfileSettings.tsx
+++ b/src/pages/Profile/components/ProfileSettings.tsx
@@ -96,7 +96,15 @@ const ProfileSettings = ({ isAdmin, user }: ProfileSettingsProps) => {
           </Select>
         </div>
         <TextField disabled={updateUser.isLoading} formState={formState} label='Kjøkkenredskap' {...register('tool')} />
-        <TextField disabled={updateUser.isLoading} formState={formState} label='Evt allergier og annen info' multiline {...register('allergy')} minRows={3} />
+        <TextField
+          disabled={updateUser.isLoading}
+          formState={formState}
+          helperText='Dine allergier vises til arrangører ved arrangementer'
+          label='Dine allergier'
+          multiline
+          {...register('allergy')}
+          minRows={3}
+        />
         <SubmitButton disabled={updateUser.isLoading} formState={formState}>
           Oppdater
         </SubmitButton>


### PR DESCRIPTION
## Description

closes #160 

Changes:
Legger til hjelpertekst i brukerprofil under allergier

Screenshots:
<img width="916" alt="Skjermbilde 2021-09-14 kl  20 20 18" src="https://user-images.githubusercontent.com/26656069/133312307-b3f9c99f-d096-44d4-8ce6-50c97997f516.png">

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [x] The PR includes a `closes #issueID`
- [x] The PR includes a picture showing visual changes
- [x] Added Google Analytics tracking if relevant
- [x] Pull request title follows [conventional commits](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) (`type(scope): description`)
- [x] CHANGELOG.md has been updated. [Guide](https://tihlde.slab.com/posts/changelog-z8hybjom)
