### PR TITLE
feat(changelog):adding captions on om index page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@
 ---
 
 ## Neste versjon
+
+✨ **Changelog**. Legger til tegnforklaringer på om-index siden
+
 - ✨ **Filterboks**. Filterboksen i arrangementer siden kan nå åpnes og lukkes på små skjermer.
 
 - ⚡ **Arrangementer**. Viser brukerens profilbilde på store skjermer ved arrangement registrering.

--- a/src/pages/Pages/specials/Index/index.tsx
+++ b/src/pages/Pages/specials/Index/index.tsx
@@ -3,9 +3,19 @@ import Changelog from 'pages/Pages/specials/Index/Changelog';
 import MembersCard from 'pages/Pages/specials/Index/MembersCard';
 import { Groups } from 'types/Enums';
 
+import Container from 'components/layout/Container';
+
 const AboutIndex = () => {
   return (
     <>
+      <Container>
+        <ul style={{listStyle: 'none'}}>
+          <li>✨ - Ny funksjonalitet</li>
+          <li>⚡ - Forbedret funksjonalitet</li>
+          <li>🦟 - Fikset en bug</li>
+          <li>🎨 - Designendringer</li>
+        </ul>
+      </Container>
       <Changelog changelogURL='https://raw.githubusercontent.com/tihlde/Kvark/master/CHANGELOG.md' title='Hva har vi gjort i frontend?' />
       <Changelog changelogURL='https://raw.githubusercontent.com/tihlde/Lepton/master/CHANGELOG.md' title='Hva har vi gjort i backend?' />
       <ErrorCard />

--- a/src/pages/Pages/specials/Index/index.tsx
+++ b/src/pages/Pages/specials/Index/index.tsx
@@ -2,20 +2,24 @@ import ErrorCard from 'pages/Pages/specials/Index/ErrorCard';
 import Changelog from 'pages/Pages/specials/Index/Changelog';
 import MembersCard from 'pages/Pages/specials/Index/MembersCard';
 import { Groups } from 'types/Enums';
+import InfoCard from 'components/layout/InfoCard';
+import { styled } from '@mui/material';
 
-import Container from 'components/layout/Container';
+const List = styled('ul')({
+  listStyleType: 'none',
+});
 
 const AboutIndex = () => {
   return (
     <>
-      <Container>
-        <ul style={{listStyle: 'none'}}>
-          <li>✨ - Ny funksjonalitet</li>
-          <li>⚡ - Forbedret funksjonalitet</li>
-          <li>🦟 - Fikset en bug</li>
-          <li>🎨 - Designendringer</li>
-        </ul>
-      </Container>
+      <InfoCard header='Tegnforklaring'>
+        <List>
+          <li>✨ Ny funksjonalitet</li>
+          <li>⚡ Forbedret funksjonalitet</li>
+          <li>🦟 Fikset en bug</li>
+          <li>🎨 Designendringer</li>
+        </List>
+      </InfoCard>
       <Changelog changelogURL='https://raw.githubusercontent.com/tihlde/Kvark/master/CHANGELOG.md' title='Hva har vi gjort i frontend?' />
       <Changelog changelogURL='https://raw.githubusercontent.com/tihlde/Lepton/master/CHANGELOG.md' title='Hva har vi gjort i backend?' />
       <ErrorCard />

--- a/src/pages/Pages/specials/Index/index.tsx
+++ b/src/pages/Pages/specials/Index/index.tsx
@@ -7,6 +7,7 @@ import { styled } from '@mui/material';
 
 const List = styled('ul')({
   listStyleType: 'none',
+  margin: 0,
 });
 
 const AboutIndex = () => {


### PR DESCRIPTION
## Description

closes #15 

Changes: Legger til tegnforklaringer på om index siden. 

Jeg vurderte å bruke infoCard komponenten, men jeg følte at det ga inntrykket av at all informasjonen var like viktig på siden, ettersom hele siden bruker infoCard komponenter til å vise informasjon.

Screenshots:
<img width="1348" alt="Skjermbilde 2021-09-28 kl  22 26 32" src="https://user-images.githubusercontent.com/26656069/135164472-b61b9cc0-752d-4985-a133-42587c0c4dbd.png">

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [X] The PR includes a `closes #issueID`
- [X] The PR includes a picture showing visual changes
- [ ] Added Google Analytics tracking if relevant
- [X] Pull request title follows [conventional commits](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) (`type(scope): description`)
- [X] CHANGELOG.md has been updated. [Guide](https://tihlde.slab.com/posts/changelog-z8hybjom)
