### PR TITLE
fix(forms): allow submit when no fields

### DIFF
--- a/src/components/forms/FormAnswers.tsx
+++ b/src/components/forms/FormAnswers.tsx
@@ -70,7 +70,7 @@ const FormAnswers = ({ formId }: FormAnswersProps) => {
               labelDisplayedRows={({ from, to, count }) => `${from}-${to} av ${count}`}
               onPageChange={(_, p) => setSelectedPage(p)}
               page={selectedPage}
-              rowsPerPage={data.results.length || 25}
+              rowsPerPage={25}
               rowsPerPageOptions={[-1]}
             />
           </TableRow>

--- a/src/components/forms/FormView.tsx
+++ b/src/components/forms/FormView.tsx
@@ -1,5 +1,6 @@
 import { Form } from 'types';
 import { UseFormReturn } from 'react-hook-form';
+import { Typography, TypographyProps } from '@mui/material';
 
 // Project components
 import FieldView from 'components/forms/FieldView';
@@ -7,26 +8,30 @@ import FieldView from 'components/forms/FieldView';
 export type FormViewProps<FormValues> = Pick<UseFormReturn<FormValues>, 'formState' | 'register' | 'control' | 'getValues'> & {
   form: Form;
   disabled?: boolean;
+  alignText?: TypographyProps['align'];
 };
 
 // eslint-disable-next-line comma-spacing
-const FormView = <FormValues,>({ form, register, formState, control, getValues, disabled = false }: FormViewProps<FormValues>) => {
-  return (
-    <>
-      {form.fields.map((field, index) => (
-        <FieldView
-          control={control}
-          disabled={disabled}
-          field={field}
-          formState={formState}
-          getValues={getValues}
-          index={index}
-          key={field.id}
-          register={register}
-        />
-      ))}
-    </>
-  );
-};
+const FormView = <FormValues,>({ form, register, formState, control, getValues, disabled = false, alignText }: FormViewProps<FormValues>) => (
+  <>
+    {!form.fields.length && (
+      <Typography align={alignText} variant='body2'>
+        Dette spørreskjemaet inneholder ingen spørsmål.
+      </Typography>
+    )}
+    {form.fields.map((field, index) => (
+      <FieldView
+        control={control}
+        disabled={disabled}
+        field={field}
+        formState={formState}
+        getValues={getValues}
+        index={index}
+        key={field.id}
+        register={register}
+      />
+    ))}
+  </>
+);
 
 export default FormView;

--- a/src/hooks/Form.tsx
+++ b/src/hooks/Form.tsx
@@ -83,7 +83,7 @@ export const useCreateSubmission = (formId: string): UseMutationResult<Submissio
 };
 
 export const validateSubmissionInput = (submission: Submission, form: Form) => {
-  submission.answers.forEach((answer, index) => {
+  submission.answers?.forEach((answer, index) => {
     const field = form.fields.find((field) => field.id === answer.field.id);
     if (field && field.type === FormFieldType.MULTIPLE_SELECT && field.required) {
       const ans = answer as SelectFieldSubmission;

--- a/src/pages/EventDetails/components/EventRegistration.tsx
+++ b/src/pages/EventDetails/components/EventRegistration.tsx
@@ -8,7 +8,7 @@ import { useSnackbar } from 'hooks/Snackbar';
 import { useForm } from 'react-hook-form';
 
 // Material UI Components
-import { Box, IconProps, Typography, FormControlLabel, Checkbox, Button } from '@mui/material';
+import { Box, IconProps, Typography, FormControlLabel, Checkbox } from '@mui/material';
 
 // Icons
 import PersonIcon from '@mui/icons-material/PersonOutlineRounded';
@@ -20,6 +20,7 @@ import HomeIcon from '@mui/icons-material/HomeRounded';
 // Project components
 import Paper from 'components/layout/Paper';
 import FormView from 'components/forms/FormView';
+import SubmitButton from 'components/inputs/SubmitButton';
 import { useGoogleAnalytics } from 'hooks/Utils';
 
 type ListItemProps = {
@@ -113,7 +114,7 @@ const EventRegistration = ({ event, user }: EventRegistrationProps) => {
             <Paper sx={{ my: 1 }}>
               <Typography variant='h3'>Spørsmål</Typography>
               <Typography gutterBottom variant='subtitle2'>
-                Arrangøren ønsker at du svarer på følgende spørsmål
+                Arrangøren ønsker at du svarer på følgende spørsmål:
               </Typography>
               <FormView control={control} disabled={isLoading || isFormLoading} form={form} formState={formState} getValues={getValues} register={register} />
             </Paper>
@@ -131,9 +132,9 @@ const EventRegistration = ({ event, user }: EventRegistrationProps) => {
           <Typography component='a' href={URLS.eventRules} rel='noopener noreferrer' target='_blank' variant='caption'>
             Les arrangementsreglene her (åpnes i ny fane)
           </Typography>
-          <Button disabled={registerDisabled} fullWidth sx={{ mt: 2 }} type='submit' variant='contained'>
+          <SubmitButton disabled={registerDisabled} formState={formState} sx={{ mt: 2 }}>
             Meld deg på
-          </Button>
+          </SubmitButton>
         </Box>
       </Box>
     </>

--- a/src/pages/Form/index.tsx
+++ b/src/pages/Form/index.tsx
@@ -10,7 +10,7 @@ import { parseISO } from 'date-fns';
 import URLS from 'URLS';
 
 // Material UI Components
-import { Divider, Button, Typography } from '@mui/material';
+import { Button, Divider, Stack, Typography } from '@mui/material';
 
 // Project Components
 import Http404 from 'pages/Http404';
@@ -18,6 +18,7 @@ import Page from 'components/navigation/Page';
 import Paper from 'components/layout/Paper';
 import { PrimaryTopBox } from 'components/layout/TopBox';
 import FormView from 'components/forms/FormView';
+import SubmitButton from 'components/inputs/SubmitButton';
 import { FormResourceType, FormType } from 'types/Enums';
 
 const FormPage = () => {
@@ -54,6 +55,7 @@ const FormPage = () => {
       return;
     }
     setIsLoading(true);
+    data.answers = data.answers || [];
     try {
       validateSubmissionInput(data, form);
     } catch (e) {
@@ -101,13 +103,35 @@ const FormPage = () => {
             </Typography>
             <Divider sx={{ my: 2 }} />
             {form.viewer_has_answered ? (
-              <Typography align='center'>Du har allerede svart på dette spørreskjemaet</Typography>
+              <>
+                <Typography align='center' variant='body2'>
+                  Du har allerede svart på dette spørreskjemaet, takk!
+                </Typography>
+                <Stack direction={{ xs: 'column', md: 'row' }} gap={1} sx={{ mt: 2 }}>
+                  <Button component={Link} fullWidth to={URLS.landing} variant='outlined'>
+                    Gå til forsiden
+                  </Button>
+                  <Button component={Link} fullWidth to={URLS.profile} variant='outlined'>
+                    Gå til profilen
+                  </Button>
+                </Stack>
+              </>
             ) : (
               <form onSubmit={handleSubmit(submit)}>
-                {form && <FormView control={control} disabled={submitDisabled} form={form} formState={formState} getValues={getValues} register={register} />}
-                <Button disabled={submitDisabled} fullWidth sx={{ mt: 2 }} type='submit' variant='contained'>
+                {form && (
+                  <FormView
+                    alignText='center'
+                    control={control}
+                    disabled={submitDisabled}
+                    form={form}
+                    formState={formState}
+                    getValues={getValues}
+                    register={register}
+                  />
+                )}
+                <SubmitButton disabled={submitDisabled} formState={formState} sx={{ mt: 2 }}>
                   Send inn svar
-                </Button>
+                </SubmitButton>
               </form>
             )}
           </>


### PR DESCRIPTION
## Description

closes # N/A

Changes:
Fixes an issue where you couldn't submit a form with no fields, resulting in that you weren't able to sign up for new events if there was an unanswered evaluationform with no fields blocking. Also added better text feedback to users and fixed a bug in the table with form-answers pagination counts.

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] The PR includes a `closes #issueID`
- [ ] The PR includes a picture showing visual changes
- [ ] Added Google Analytics tracking if relevant
- [x] Pull request title follows [conventional commits](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) (`type(scope): description`)
- [ ] CHANGELOG.md has been updated. [Guide](https://tihlde.slab.com/posts/changelog-z8hybjom)
