### PR TITLE
fix(changelogger): no new pr on branch update

### DIFF
--- a/.github/workflows/changelogger.yml
+++ b/.github/workflows/changelogger.yml
@@ -2,6 +2,7 @@ name: Changelogger
 
 on:
   pull_request:
+    types: [opened]
     branches:
       - master
 


### PR DESCRIPTION
## Description

closes #

Changes:
Stops issue where it's created a new PR to update the changelog when the first pr to update the changelog is merged into dev.

Screenshots:

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] The PR includes a `closes #issueID`
- [ ] The PR includes a picture showing visual changes
- [ ] Added Google Analytics tracking if relevant
- [x] Pull request title follows [conventional commits](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) (`type(scope): description`)
- [ ] CHANGELOG.md has been updated. [Guide](https://tihlde.slab.com/posts/changelog-z8hybjom)
