### PR TITLE
feat(eventadmin): add button to download event-answers as csv

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,10 @@
 
 ## Neste versjon
 
+✨ **Arrangementer**. Muligheten for å laste ned svar på arrangementer som en csv fil.
+
 ## Versjon 1.2.2 (28.09.2021)
+
 - ✨ **Filterboks**. Filterboksen i arrangementer siden kan nå åpnes og lukkes på små skjermer.
 
 - ⚡ **Arrangementer**. Viser brukerens profilbilde på store skjermer ved arrangement registrering.

--- a/src/components/forms/FormAnswers.tsx
+++ b/src/components/forms/FormAnswers.tsx
@@ -8,6 +8,7 @@ import { TOKEN_HEADER_NAME, TIHLDE_API_URL, ACCESS_TOKEN } from 'constant';
 
 // Material UI
 import { Button, Typography, Table, TableBody, TableCell, TableContainer, TableHead, TableRow, TableFooter, TablePagination } from '@mui/material';
+import DownloadIcon from '@mui/icons-material/FileDownloadRounded';
 
 // Project components
 import Paper from 'components/layout/Paper';
@@ -64,8 +65,8 @@ const FormAnswers = ({ formId }: FormAnswersProps) => {
 
   return (
     <>
-      <Button onClick={downloadCSV} size='small' sx={{ width: 'fit-content', height: 35, mb: 2, ml: 'auto' }} variant='contained'>
-        Last ned CSV
+      <Button endIcon={<DownloadIcon />} onClick={downloadCSV} size='small' sx={{ width: 'fit-content', height: 35, mb: 2, ml: 'auto' }} variant='contained'>
+        Last ned som csv
       </Button>
       <TableContainer component={Paper} noPadding>
         <Table aria-label={`Svar for ${form.title}`} size='small' sx={{ minWidth: 250 }}>


### PR DESCRIPTION
## Description

closes #164 

Changes: Legger til knapp for å kunne laste ned svar på arrangementer som en csv fil.

Screenshots:

<img width="937" alt="Skjermbilde 2021-09-28 kl  19 05 08" src="https://user-images.githubusercontent.com/26656069/135133000-94209e5a-77f2-4a2f-b471-aa2b677ed94e.png">

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [X] The PR includes a `closes #issueID`
- [X] The PR includes a picture showing visual changes
- [ ] Added Google Analytics tracking if relevant
- [X] Pull request title follows [conventional commits](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) (`type(scope): description`)
- [X] CHANGELOG.md has been updated. [Guide](https://tihlde.slab.com/posts/changelog-z8hybjom)
