### PR TITLE
Feat(events) users can sign of events 2 hours before start

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 ## Neste versjon
 
 - ✨ **Changelog**. Expand bokser i changelog for å se tidligere endringer/versjoner.
+- ✨ **Arrangementer**. Brukere kan melde seg av arrangementer opp til 2 timer før start, med blir varslet om at de får prikk.
 
 ## Versjon 1.2.3 (29.09.2021)
 

--- a/src/pages/EventDetails/components/EventRenderer.tsx
+++ b/src/pages/EventDetails/components/EventRenderer.tsx
@@ -3,7 +3,7 @@ import classnames from 'classnames';
 import { Event } from 'types';
 import { PermissionApp } from 'types/Enums';
 import URLS from 'URLS';
-import { parseISO, isPast, isFuture } from 'date-fns';
+import { parseISO, isPast, isFuture, sub } from 'date-fns';
 import { formatDate, getICSFromEvent } from 'utils';
 import { Link } from 'react-router-dom';
 
@@ -180,12 +180,26 @@ const EventRenderer = ({ data, preview = false }: EventRendererProps) => {
             variant='outlined'>
             Meld deg av
           </VerifyDialog>
-        ) : (
-          isFuture(startDate) && (
-            <Alert severity='info' variant='outlined'>
-              Avmeldingsfristen er passert
+        ) : isFuture(sub(Date.parse(data.start_date), { hours: 2 })) ? (
+          <>
+            <VerifyDialog
+              closeText='Avbryt'
+              confirmText='Ja, jeg er sikker'
+              contentText={`Om du melder deg av nå vil du ikke kunne melde deg på igjen. I tillegg vil du få en prikk.`}
+              fullWidth
+              onConfirm={signOff}
+              titleText='Er du sikker?'
+              variant='outlined'>
+              Meld deg av
+            </VerifyDialog>
+            <Alert severity='warning' variant='outlined'>
+              Avmeldingsfristen har passert. Hvis du melder deg av nå, vil du få 1 prikk.
             </Alert>
-          )
+          </>
+        ) : (
+          <Alert severity='warning' variant='outlined'>
+            Du kan ikke lengre melde deg av arrangementet
+          </Alert>
         )}
       </>
     );


### PR DESCRIPTION
## Description

closes #221 

Changes: Changes: Lar brukere melde seg av arrangementer opp til 2 timer for arrangement start. De blir varslet om at de kan får en prikk med an Alert boks og ett pop up vindu. 

Screenshots:
<img width="559" alt="Skjermbilde 2021-10-02 kl  17 21 33" src="https://user-images.githubusercontent.com/26656069/135722841-36b4268b-abd8-413f-b265-5c300a60ced1.png">
<img width="821" alt="Skjermbilde 2021-10-02 kl  17 21 42" src="https://user-images.githubusercontent.com/26656069/135722842-3fc2d6de-78a1-4688-9df1-577899991594.png">

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [X] The PR includes a `closes #issueID`
- [X] The PR includes a picture showing visual changes
- [ ] Added Google Analytics tracking if relevant
- [X] Pull request title follows [conventional commits](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) (`type(scope): description`)
- [X] CHANGELOG.md has been updated. [Guide](https://tihlde.slab.com/posts/changelog-z8hybjom)
