### PR TITLE
refactor(strikes): show strike destroy button dynamically

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@
 ---
 
 ## Neste versjon
+
+- ⚡ **Prikker**. Kun HS og Index får nå tilgang til å slette prikker.
 - ✨ **Arrangementer**. Brukere kan melde seg av arrangementer opp til 2 timer før start, men blir varslet om at de får prikk.
 
 ## Versjon 1.2.4 (05.10.2021)
@@ -22,7 +24,6 @@
 - ✨ **Prikker**. Admins har mulighet til å gi deltagere på arrangementer prikker, se prikkene de allerede har mottatt og slette dem
 - ✨ **Changelog**. Expand bokser i changelog for å se tidligere endringer/versjoner.
 - 🦟 **Varslinger**. Varslings-boksen lukkes ved klikk ppå link
-
 
 ## Versjon 1.2.3 (29.09.2021)
 

--- a/src/components/miscellaneous/StrikeListItem.tsx
+++ b/src/components/miscellaneous/StrikeListItem.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import { parseISO } from 'date-fns';
 import { Strike, User } from 'types';
 import { formatDate } from 'utils';
+import { useUser } from 'hooks/User';
 import { useDeleteStrike } from 'hooks/Strike';
 import { ListItem, ListItemText, ListItemButton, ListItemProps, Typography, Collapse, Stack, Divider } from '@mui/material';
 
@@ -16,11 +17,10 @@ import EventListItem from 'components/miscellaneous/ListItem';
 export type StrikeProps = {
   strike: Strike;
   userId: User['user_id'];
-  /** Should the viewer see edit and delete options? */
-  isAdmin?: boolean;
 } & ListItemProps;
 
-const StrikeListItem = ({ strike, userId, isAdmin = false, ...props }: StrikeProps) => {
+const StrikeListItem = ({ strike, userId, ...props }: StrikeProps) => {
+  const { data: user } = useUser();
   const deleteStrike = useDeleteStrike(userId);
   const [expanded, setExpanded] = useState(false);
   const deleteHandler = () => deleteStrike.mutate(strike.id);
@@ -39,13 +39,13 @@ const StrikeListItem = ({ strike, userId, isAdmin = false, ...props }: StrikePro
         <Divider />
         <Stack gap={1} sx={{ p: 2 }}>
           <div>
-            {isAdmin && Boolean(strike.creator) && (
+            {user?.permissions.strike.read && Boolean(strike.creator) && (
               <Typography variant='subtitle2'>{`Opprettet av: ${strike.creator?.first_name} ${strike.creator?.last_name}`}</Typography>
             )}
             <Typography variant='subtitle2'>{`Opprettet: ${formatDate(parseISO(strike.created_at))}`}</Typography>
           </div>
           {strike.event !== undefined && <EventListItem event={strike.event} />}
-          {isAdmin && (
+          {user?.permissions.strike.destroy && (
             <VerifyDialog color='error' contentText={`Er du sikker på at du vil slette denne prikken?`} onConfirm={deleteHandler} startIcon={<Delete />}>
               Slett prikk
             </VerifyDialog>

--- a/src/hooks/Strike.tsx
+++ b/src/hooks/Strike.tsx
@@ -15,6 +15,9 @@ export const useCreateStrike = () => {
       queryClient.invalidateQueries([USER_STRIKES_QUERY_KEY, variables.user_id]);
       showSnackbar('Prikken ble opprettet', 'success');
     },
+    onError: (e) => {
+      showSnackbar(e.detail, 'error');
+    },
   });
 };
 
@@ -26,6 +29,9 @@ export const useDeleteStrike = (userId: string) => {
       queryClient.invalidateQueries([ALL_STRIKES_QUERY_KEY]);
       queryClient.invalidateQueries([USER_STRIKES_QUERY_KEY, userId]);
       showSnackbar('Prikken ble slettet', 'success');
+    },
+    onError: (e) => {
+      showSnackbar(e.detail, 'error');
     },
   });
 };

--- a/src/pages/EventAdministration/components/Participant.tsx
+++ b/src/pages/EventAdministration/components/Participant.tsx
@@ -75,7 +75,7 @@ const Participant = ({ registration, eventId }: ParticipantProps) => {
         <Typography variant='subtitle1'>{`Alle prikker (${data.reduce((val, strike) => val + strike.strike_size, 0)}):`}</Typography>
         <Stack gap={1}>
           {data.map((strike) => (
-            <StrikeListItem isAdmin key={strike.id} strike={strike} userId={registration.user_info.user_id} />
+            <StrikeListItem key={strike.id} strike={strike} userId={registration.user_info.user_id} />
           ))}
           {!data.length && (
             <Typography variant='subtitle2'>{`${registration.user_info.first_name} ${registration.user_info.last_name} har ingen aktive prikker`}</Typography>

--- a/src/types/Enums.tsx
+++ b/src/types/Enums.tsx
@@ -42,6 +42,7 @@ export enum PermissionApp {
   JOBPOST = 'jobpost',
   NEWS = 'news',
   PAGE = 'page',
+  STRIKE = 'strike',
   USER = 'user',
 }
 export enum Groups {

--- a/src/types/Misc.tsx
+++ b/src/types/Misc.tsx
@@ -55,6 +55,7 @@ export interface PaginationResponse<T> {
 export interface Permissions {
   write: boolean;
   read: boolean;
+  destroy?: boolean;
 }
 
 export interface RequestResponse {


### PR DESCRIPTION
## Description

Oppdatering som samsvarer med endringer i #TIHLDE/Lepton#290

Changes:
- Kun personer med tilgang til å slette prikker (HS og Index) får nå se slette-knappen

Screenshots:

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [x] The PR includes a `closes #issueID`
- [x] The PR includes a picture showing visual changes
- [x] Added Google Analytics tracking if relevant
- [x] Pull request title follows [conventional commits](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) (`type(scope): description`)
- [x] CHANGELOG.md has been updated. [Guide](https://tihlde.slab.com/posts/changelog-z8hybjom)
