### PR TITLE
feat(form-templates): Implementing form templates 

### DIFF
--- a/src/api/api.tsx
+++ b/src/api/api.tsx
@@ -97,6 +97,7 @@ export default {
 
   // Forms
   getForm: (formId: string) => IFetch<Form>({ method: 'GET', url: `${FORMS_ENDPOINT}/${formId}/` }),
+  getFormTemplates: () => IFetch<Array<Form>>({ method: 'GET', url: `${FORMS_ENDPOINT}/` }),
   getFormStatistics: (formId: string) => IFetch<FormStatistics>({ method: 'GET', url: `${FORMS_ENDPOINT}/${formId}/statistics/` }),
   createForm: (item: FormCreate | EventFormCreate) => IFetch<Form>({ method: 'POST', url: `${FORMS_ENDPOINT}/`, data: item }),
   updateForm: (formId: string, item: FormUpdate) => IFetch<Form>({ method: 'PUT', url: `${FORMS_ENDPOINT}/${formId}/`, data: item }),

--- a/src/hooks/Form.tsx
+++ b/src/hooks/Form.tsx
@@ -23,6 +23,8 @@ export const STATISTICS_QUERY_KEY = 'statistics';
 
 export const useFormById = (formId: string) =>
   useQuery<Form, RequestResponse>([FORM_QUERY_KEY, formId], () => API.getForm(formId), { enabled: formId !== '-' });
+export const useFormTemplates = () => useQuery<Array<Form>, RequestResponse>([FORM_QUERY_KEY], () => API.getFormTemplates(), {});
+
 export const useFormStatisticsById = (formId: string) =>
   useQuery<FormStatistics, RequestResponse>([FORM_QUERY_KEY, formId, STATISTICS_QUERY_KEY], () => API.getFormStatistics(formId), { enabled: formId !== '-' });
 

--- a/src/pages/EventAdministration/components/EventFormEditor.tsx
+++ b/src/pages/EventAdministration/components/EventFormEditor.tsx
@@ -23,6 +23,7 @@ const EventFormEditor = ({ eventId, formId, formType }: EventFormEditorProps) =>
   const [addButtonOpen, setAddButtonOpen] = useState(false);
   const buttonAnchorRef = useRef(null);
   const { data: formTemplates = [] } = useFormTemplates();
+  console.log(formTemplates)
   const newForm: EventFormCreate = {
     title: String(eventId),
     type: formType,
@@ -36,30 +37,9 @@ const EventFormEditor = ({ eventId, formId, formType }: EventFormEditorProps) =>
   if (!formId) {
     return (
       <Box>
-        <Button fullWidth onClick={() => setAddButtonOpen(true)} ref={buttonAnchorRef} variant='outlined'>
+        <Button fullWidth onClick={() => onCreate()} variant='outlined'>
           Opprett skjema
         </Button>
-        <Popper anchorEl={buttonAnchorRef.current} open={addButtonOpen} role={undefined} transition>
-          {({ TransitionProps }) => (
-            <Grow {...TransitionProps}>
-              <Paper>
-                <ClickAwayListener onClickAway={() => setAddButtonOpen(false)}>
-                  <MenuList id='menu-list-grow'>
-                    <MenuItem divider={true} onClick={() => onCreate(newForm)}>
-                      Tomt skjema
-                    </MenuItem>
-                    {formTemplates &&
-                      formTemplates.map((formTemplate) => (
-                        <MenuItem key={formTemplate.id} onClick={() => onCreate(formTemplate)}>
-                          {formTemplate.type}
-                        </MenuItem>
-                      ))}
-                  </MenuList>
-                </ClickAwayListener>
-              </Paper>
-            </Grow>
-          )}
-        </Popper>
       </Box>
     );
   } else if (isLoading || !data || !submissions) {

--- a/src/pages/EventAdministration/components/EventFormEditor.tsx
+++ b/src/pages/EventAdministration/components/EventFormEditor.tsx
@@ -1,12 +1,14 @@
-import { EventFormCreate } from 'types';
-import { useFormById, useCreateForm, useFormSubmissions } from 'hooks/Form';
+import { useState, useRef } from 'react';
+import { EventFormCreate, Form } from 'types';
+import { useFormById, useCreateForm, useFormSubmissions, useFormTemplates } from 'hooks/Form';
 
 // Material UI
-import { Typography, Button } from '@mui/material';
+import { Typography, Button, Popper, Grow, Paper, ClickAwayListener, MenuList, MenuItem } from '@mui/material';
 
 // Project components
 import FormEditor from 'components/forms/FormEditor';
 import { FormType, FormResourceType } from 'types/Enums';
+import { Box } from '@mui/system';
 
 export type EventFormEditorProps = {
   eventId: number;
@@ -18,7 +20,9 @@ const EventFormEditor = ({ eventId, formId, formType }: EventFormEditorProps) =>
   const { data, isLoading } = useFormById(formId || '-');
   const { data: submissions } = useFormSubmissions(formId || '-', 1);
   const createForm = useCreateForm();
-
+  const [addButtonOpen, setAddButtonOpen] = useState(false);
+  const buttonAnchorRef = useRef(null);
+  const { data: formTemplates = [] } = useFormTemplates();
   const newForm: EventFormCreate = {
     title: String(eventId),
     type: formType,
@@ -27,13 +31,36 @@ const EventFormEditor = ({ eventId, formId, formType }: EventFormEditorProps) =>
     fields: [],
   };
 
-  const onCreate = async () => createForm.mutate(newForm);
+  const onCreate = async (formTemplate: Form | EventFormCreate) => createForm.mutate(formTemplate);
 
   if (!formId) {
     return (
-      <Button fullWidth onClick={onCreate} variant='outlined'>
-        Opprett skjema
-      </Button>
+      <Box>
+        <Button fullWidth onClick={() => setAddButtonOpen(true)} ref={buttonAnchorRef} variant='outlined'>
+          Opprett skjema
+        </Button>
+        <Popper anchorEl={buttonAnchorRef.current} open={addButtonOpen} role={undefined} transition>
+          {({ TransitionProps }) => (
+            <Grow {...TransitionProps}>
+              <Paper>
+                <ClickAwayListener onClickAway={() => setAddButtonOpen(false)}>
+                  <MenuList id='menu-list-grow'>
+                    <MenuItem divider={true} onClick={() => onCreate(newForm)}>
+                      Tomt skjema
+                    </MenuItem>
+                    {formTemplates &&
+                      formTemplates.map((formTemplate) => (
+                        <MenuItem key={formTemplate.id} onClick={() => onCreate(formTemplate)}>
+                          {formTemplate.type}
+                        </MenuItem>
+                      ))}
+                  </MenuList>
+                </ClickAwayListener>
+              </Paper>
+            </Grow>
+          )}
+        </Popper>
+      </Box>
     );
   } else if (isLoading || !data || !submissions) {
     return <Typography variant='body2'>Laster skjemaet</Typography>;

--- a/src/pages/EventAdministration/components/EventFormEditor.tsx
+++ b/src/pages/EventAdministration/components/EventFormEditor.tsx
@@ -91,7 +91,7 @@ const EventFormEditor = ({ eventId, formId, formType }: EventFormEditorProps) =>
   } else if (isLoading || !data || !submissions) {
     return <Typography variant='body2'>Laster skjemaet</Typography>;
   } else if (submissions.count) {
-    return <Typography variant='body2'>Du kan ikke endre spørsmålene etter at noen har svart på dem</Typography>;
+    return <Typography variant='body2'>Du kan ikke endre spørsmålene etter at noen har svart på dem.</Typography>;
   }
 
   return <FormEditor form={data} />;

--- a/src/types/Enums.tsx
+++ b/src/types/Enums.tsx
@@ -59,6 +59,7 @@ export enum FormType {
 }
 
 export enum FormResourceType {
+  FORM = 'Form',
   EVENT_FORM = 'EventForm',
 }
 

--- a/src/types/Form.tsx
+++ b/src/types/Form.tsx
@@ -13,9 +13,10 @@ export interface Form {
   fields: Array<TextFormField | SelectFormField>;
   resource_type: FormResourceType;
   viewer_has_answered: boolean;
+  template: boolean;
 }
 
-export type FormCreate = Omit<Form, 'id' | 'viewer_has_answered'>;
+export type FormCreate = Omit<Form, 'id' | 'viewer_has_answered' | 'type'> & Partial<Pick<Form, 'type'>>;
 export type FormUpdate = Partial<Form> & Pick<Form, 'fields' | 'resource_type'>;
 
 export interface EventForm extends Form {


### PR DESCRIPTION
## Description

Legger til muligheten for å bruke en ferdiglaget mal for å oprette spørre- og evaluering-skjemaer.

closes #194 

Changes:
Måtte implementere en liten "hack" for å fjerne all ID fra formtemplates, ettersom det nye skjemaet må ha sine egne unike IDer. 

Screenshots:
<img width="1021" alt="Skjermbilde 2021-11-04 kl  13 48 18" src="https://user-images.githubusercontent.com/26656069/140316217-2398ad77-feb7-4e89-8a42-721d1c371f4b.png">

<img width="1022" alt="Skjermbilde 2021-11-04 kl  13 59 58" src="https://user-images.githubusercontent.com/26656069/140317751-52dea847-c604-43e3-9ab7-86827d7dcaec.png">

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] The PR includes a `closes #issueID`
- [ ] The PR includes a picture showing visual changes
- [ ] Added Google Analytics tracking if relevant
- [ ] Pull request title follows [conventional commits](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) (`type(scope): description`)
- [ ] CHANGELOG.md has been updated. [Guide](https://tihlde.slab.com/posts/changelog-z8hybjom)
