### PR TITLE
feat(badges): add rickrolled badge

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -11,6 +11,7 @@ import { broadcastQueryClient } from 'react-query/broadcastQueryClient-experimen
 import { ReactQueryDevtools } from 'react-query/devtools';
 import 'delayed-scroll-restoration-polyfill';
 import { SHOW_NEW_STUDENT_INFO } from 'constant';
+import API from 'api/api';
 
 // Services
 import { ThemeProvider } from 'hooks/Theme';
@@ -96,6 +97,8 @@ console.log(
   '',
 );
 const rickroll = () => {
+  const RICKROLLED_BADGE_ID = '8e4eb14a-77f5-4a10-b3ae-548d0f607528';
+  API.createUserBadge({ badge_id: RICKROLLED_BADGE_ID }).catch(() => null);
   window.gtag('event', 'rickrolled', {
     event_category: 'easter-egg',
     event_label: 'Rickrolled in the console',


### PR DESCRIPTION
## Description

Users now get a "Rickrolled"-badge when they type `badge()` into the console.

Added the badge to both the prod and dev-api with the same id, so it works both places.

Changes:

Screenshots:
![image](https://user-images.githubusercontent.com/31009729/141164878-e78c3dd5-1b94-4965-bc4c-b06699762d18.png)


## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] The PR includes a `closes #issueID`
- [x] The PR includes a picture showing visual changes
- [x] Added Google Analytics tracking if relevant
- [x] Pull request title follows [conventional commits](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) (`type(scope): description`)
- [ ] CHANGELOG.md has been updated. [Guide](https://tihlde.slab.com/posts/changelog-z8hybjom)
