### PR TITLE
feat(events): countdown to registration and prioritized indicator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 ## Neste versjon
 
+- ⚡ **Arrangementer**. Brukere kan nå se om de er prioritert på et arrangement.
 - ⚡ **Arrangementer**. Påmeldingsknappen teller ned til påmeldingsstart og aktiveres automatisk ved påmeldingsstart uten at en må laste inn siden på nytt.
 - ✨ **Kokeboka**. Lagt til "Antall koker nå" teller (ikke faktiske tall).
 - ⚡ **Botsystem**. Lovverket er bedre sortert. Ved ny bot endres beløp når valgt lovbrudd endres.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 ## Neste versjon
 
+- ⚡ **Arrangementer**. Påmeldingsknappen teller ned til påmeldingsstart og aktiveres automatisk ved påmeldingsstart uten at en må laste inn siden på nytt.
 - ✨ **Kokeboka**. Lagt til "Antall koker nå" teller (ikke faktiske tall).
 - ⚡ **Botsystem**. Lovverket er bedre sortert. Ved ny bot endres beløp når valgt lovbrudd endres.
 

--- a/src/components/navigation/TopbarNotifications.tsx
+++ b/src/components/navigation/TopbarNotifications.tsx
@@ -1,8 +1,8 @@
-import { useEffect, useState, useMemo, useRef } from 'react';
+import { useState, useMemo, useRef } from 'react';
 import parseISO from 'date-fns/parseISO';
 import { Link } from 'react-router-dom';
 import { Notification } from 'types';
-import { useNotifications, useUpdateNotification } from 'hooks/Notification';
+import { useNotifications } from 'hooks/Notification';
 import { getTimeSince, isExternalURL } from 'utils';
 import { useUser } from 'hooks/User';
 
@@ -55,15 +55,6 @@ export type NotificationsTopbarProps = {
 const NotificationItem = ({ notification, setShowNotifications }: NotificationItemProps) => {
   const [showDescription, setShowDescription] = useState(false);
   const { event } = useGoogleAnalytics();
-  const updateNotification = useUpdateNotification(notification.id);
-
-  useEffect(() => {
-    return () => {
-      if (!notification.read) {
-        updateNotification.mutate(true);
-      }
-    };
-  }, [notification]);
 
   const Icon = notification.read ? NotificationReadIcon : NotificationUnreadIcon;
 

--- a/src/components/navigation/TopbarNotifications.tsx
+++ b/src/components/navigation/TopbarNotifications.tsx
@@ -128,7 +128,7 @@ const NotificationItemLoading = () => (
 const NotificationsTopbar = ({ color }: NotificationsTopbarProps) => {
   const [showNotifications, setShowNotifications] = useState(false);
   const { data: user } = useUser();
-  const { data, error, hasNextPage, fetchNextPage, isLoading, isFetching } = useNotifications();
+  const { data, error, hasNextPage, fetchNextPage, isLoading, isFetching } = useNotifications({ enabled: showNotifications });
   const isEmpty = useMemo(() => (data !== undefined ? !data.pages.some((page) => Boolean(page.results.length)) : false), [data]);
   const notifications = useMemo(() => (data ? data.pages.map((page) => page.results).flat() : []), [data]);
   const mdDown = useMediaQuery((theme: Theme) => theme.breakpoints.down('lg'));
@@ -171,11 +171,11 @@ const NotificationsTopbar = ({ color }: NotificationsTopbarProps) => {
         </Badge>
       </IconButton>
       {mdDown ? (
-        <Dialog fullScreen onClose={() => setShowNotifications(false)} open={showNotifications}>
+        <Dialog fullScreen onClose={() => setShowNotifications(false)} open={showNotifications && !isLoading}>
           <NotificationsList />
         </Dialog>
       ) : (
-        <Popper anchorEl={buttonAnchorRef.current} disablePortal open={showNotifications} role={undefined} transition>
+        <Popper anchorEl={buttonAnchorRef.current} disablePortal open={showNotifications && !isLoading} role={undefined} transition>
           {({ TransitionProps }) => (
             <Grow {...TransitionProps} style={{ transformOrigin: 'right top' }}>
               <Paper elevation={2} noPadding sx={{ maxWidth: (theme) => theme.breakpoints.values.md }}>

--- a/src/hooks/Notification.tsx
+++ b/src/hooks/Notification.tsx
@@ -1,15 +1,24 @@
-import { useMutation, useInfiniteQuery, useQueryClient, UseMutationResult } from 'react-query';
+import { useMutation, useInfiniteQuery, useQueryClient, UseInfiniteQueryOptions, UseMutationResult, QueryKey } from 'react-query';
 import API from 'api/api';
 import { Notification, PaginationResponse, RequestResponse } from 'types';
 import { USER_QUERY_KEY } from 'hooks/User';
 
 export const NOTIFICATION_QUERY_KEY = 'notification';
 
-export const useNotifications = () => {
+export const useNotifications = (
+  options?: UseInfiniteQueryOptions<
+    PaginationResponse<Notification>,
+    RequestResponse,
+    PaginationResponse<Notification>,
+    PaginationResponse<Notification>,
+    QueryKey
+  >,
+) => {
   return useInfiniteQuery<PaginationResponse<Notification>, RequestResponse>(
     [NOTIFICATION_QUERY_KEY],
     ({ pageParam = 1 }) => API.getNotifications({ page: pageParam }),
     {
+      ...options,
       getNextPageParam: (lastPage) => lastPage.next,
     },
   );

--- a/src/hooks/Notification.tsx
+++ b/src/hooks/Notification.tsx
@@ -1,4 +1,5 @@
-import { useMutation, useInfiniteQuery, useQueryClient, UseInfiniteQueryOptions, UseMutationResult, QueryKey } from 'react-query';
+import { useState, useEffect } from 'react';
+import { useInfiniteQuery, useQueryClient, UseInfiniteQueryOptions, InfiniteData, QueryKey } from 'react-query';
 import API from 'api/api';
 import { Notification, PaginationResponse, RequestResponse } from 'types';
 import { USER_QUERY_KEY } from 'hooks/User';
@@ -14,22 +15,39 @@ export const useNotifications = (
     QueryKey
   >,
 ) => {
+  const queryClient = useQueryClient();
+  const [newQueryData, setNewQueryData] = useState<InfiniteData<PaginationResponse<Notification>> | null>(null);
+  const enabled = options?.enabled || false;
+
+  // Don't run `setQueryData` until the notifications are hidden (`options?.enabled === false`) to prevent unwanted UI-updates
+  useEffect(() => {
+    if (!enabled && newQueryData) {
+      queryClient.setQueryData([NOTIFICATION_QUERY_KEY], () => newQueryData);
+      setNewQueryData(null);
+    }
+  }, [enabled, newQueryData]);
+
   return useInfiniteQuery<PaginationResponse<Notification>, RequestResponse>(
     [NOTIFICATION_QUERY_KEY],
     ({ pageParam = 1 }) => API.getNotifications({ page: pageParam }),
     {
       ...options,
       getNextPageParam: (lastPage) => lastPage.next,
+      onSuccess: async (data) => {
+        // Get not read notifications
+        const notifications = data.pages
+          .map((page) => page.results)
+          .flat()
+          .filter((not) => !not.read);
+        // If some not read notifications exists, mark them as read
+        if (notifications.length) {
+          await Promise.allSettled(notifications.map((notification) => API.updateNotification(notification.id, { read: true })));
+          const newPagesArray = data.pages.map((page) => ({ ...page, results: page.results.map((val) => ({ ...val, read: true })) }));
+          queryClient.invalidateQueries([USER_QUERY_KEY]);
+          // Update the NewQueryData-variable.
+          setNewQueryData({ pages: newPagesArray, pageParams: data.pageParams });
+        }
+      },
     },
   );
-};
-
-export const useUpdateNotification = (id: number): UseMutationResult<Notification, RequestResponse, boolean, unknown> => {
-  const queryClient = useQueryClient();
-  return useMutation((newReadState: boolean) => API.updateNotification(id, { read: newReadState }), {
-    onSuccess: () => {
-      queryClient.invalidateQueries([NOTIFICATION_QUERY_KEY]);
-      queryClient.invalidateQueries([USER_QUERY_KEY]);
-    },
-  });
 };

--- a/src/hooks/Utils.tsx
+++ b/src/hooks/Utils.tsx
@@ -86,7 +86,6 @@ export const useShare = (shareData: globalThis.ShareData, fallbackSnackbar?: str
         .then(() => setShared(true))
         .catch(() => copyToClipboard(fallbackCopyText, true));
     } else {
-      showSnackbar('else', 'error');
       copyToClipboard(fallbackCopyText);
     }
     if (onShare) {

--- a/src/pages/EventDetails/components/EventPriorities.tsx
+++ b/src/pages/EventDetails/components/EventPriorities.tsx
@@ -1,11 +1,12 @@
 import { useMemo } from 'react';
 import { RegistrationPriority } from 'types';
 import { UserClass, UserStudy } from 'types/Enums';
+import { useUser } from 'hooks/User';
 import { getUserStudyShort } from 'utils';
-import { Typography, Stack, styled } from '@mui/material';
+import { Typography, Stack, Tooltip, styled, alpha } from '@mui/material';
 
 const Item = styled(Typography)(({ theme }) => ({
-  padding: '0 3px',
+  padding: theme.spacing(0, 0.75),
   border: theme.palette.borderWidth + ' solid ' + theme.palette.divider,
   borderRadius: theme.shape.borderRadius,
   margin: 3,
@@ -17,31 +18,48 @@ export type EventPrioritesProps = {
 };
 
 const EventPriorities = ({ priorities }: EventPrioritesProps) => {
+  const { data: user } = useUser();
   const prioritiesArray = useMemo(() => {
-    const arr: Array<string> = [];
+    const arr: Array<{ label: string; member_of: boolean }> = [];
     [UserStudy.DATAING, UserStudy.DIGFOR, UserStudy.DIGSEC, UserStudy.DIGSAM, UserStudy.INFO].forEach((study: UserStudy) => {
       const classes_in_study = study === UserStudy.DIGSAM ? [UserClass.FOURTH, UserClass.FIFTH] : [UserClass.FIRST, UserClass.SECOND, UserClass.THIRD];
       const all_classes_in_study_prioritized = classes_in_study.every((user_class) =>
         priorities.some((item) => item.user_class === user_class && item.user_study === study),
       );
       if (all_classes_in_study_prioritized) {
-        arr.push(getUserStudyShort(study));
+        arr.push({
+          label: getUserStudyShort(study),
+          member_of: classes_in_study.some((user_class) => user_class === user?.user_class && study === user?.user_study),
+        });
       } else {
         priorities
           .filter((priority) => priority.user_study === study)
-          .forEach((priority) => arr.push(`${priority.user_class}. ${getUserStudyShort(priority.user_study)}`));
+          .forEach((priority) =>
+            arr.push({
+              label: `${priority.user_class}. ${getUserStudyShort(priority.user_study)}`,
+              member_of: priority.user_class === user?.user_class && priority.user_study === user?.user_study,
+            }),
+          );
       }
     });
     return arr;
-  }, [priorities]);
+  }, [priorities, user]);
 
   return (
     <Stack direction='row' flexWrap='wrap'>
-      {prioritiesArray.map((priority, index) => (
-        <Item key={index} variant='subtitle1'>
-          {priority}
-        </Item>
-      ))}
+      {prioritiesArray.map((priority, index) =>
+        priority.member_of ? (
+          <Tooltip arrow key={index} title='Du er medlem av denne klassen/studiet og er dermed prioritert på dette arrangementet'>
+            <Item sx={{ borderColor: (theme) => alpha(theme.palette.info.dark, 0.8) }} variant='subtitle1'>
+              {priority.label}
+            </Item>
+          </Tooltip>
+        ) : (
+          <Item key={index} variant='subtitle1'>
+            {priority.label}
+          </Item>
+        ),
+      )}
     </Stack>
   );
 };

--- a/src/pages/EventDetails/components/EventRenderer.tsx
+++ b/src/pages/EventDetails/components/EventRenderer.tsx
@@ -11,10 +11,7 @@ import { useUser } from 'hooks/User';
 import { useSnackbar } from 'hooks/Snackbar';
 import { useGoogleAnalytics, useInterval } from 'hooks/Utils';
 import { useCategories } from 'hooks/Categories';
-
-// Material UI Components
-import { makeStyles } from 'makeStyles';
-import { Typography, Button, Collapse, Skeleton, Alert as MuiAlert, useMediaQuery, Theme, styled } from '@mui/material';
+import { Typography, Button, Collapse, Skeleton, Alert, useMediaQuery, Theme, Stack, styled } from '@mui/material';
 
 // Icons
 import CalendarIcon from '@mui/icons-material/EventRounded';
@@ -33,56 +30,20 @@ import Expand from 'components/layout/Expand';
 import VerifyDialog from 'components/layout/VerifyDialog';
 import { EventsSubscription } from 'pages/Profile/components/ProfileEvents';
 
-const Alert = styled(MuiAlert)({
-  mb: 1,
-});
-
 const DetailsPaper = styled(Paper)(({ theme }) => ({
   padding: theme.spacing(1, 2),
   display: 'grid',
   gap: theme.spacing(1),
 }));
 
-const ContentPaper = styled(Paper)(({ theme }) => ({
+const ContentPaper = styled(Paper)({
   height: 'fit-content',
   overflowX: 'auto',
-  [theme.breakpoints.down('md')]: {
-    order: 1,
-  },
-  marginBottom: theme.spacing(1),
-}));
+});
 
 const DetailsHeader = styled(Typography)({
   fontSize: '1.5rem',
 });
-
-const useStyles = makeStyles()((theme) => ({
-  rootGrid: {
-    display: 'grid',
-    gridTemplateColumns: '335px 1fr',
-    gridTemplateRows: 'auto',
-    gridGap: theme.spacing(1),
-    marginTop: theme.spacing(2),
-    position: 'relative',
-    alignItems: 'self-start',
-    [theme.breakpoints.down('lg')]: {
-      gridTemplateColumns: '100%',
-      justifyContent: 'center',
-      gridGap: theme.spacing(1),
-      marginTop: theme.spacing(1),
-    },
-  },
-  infoGrid: {
-    display: 'grid',
-    gridGap: theme.spacing(1),
-    alignItems: 'self-start',
-  },
-  info: {
-    [theme.breakpoints.down('lg')]: {
-      gridRow: '1 / 2',
-    },
-  },
-}));
 
 export type EventRendererProps = {
   data: Event;
@@ -96,7 +57,6 @@ enum Views {
 
 const EventRenderer = ({ data, preview = false }: EventRendererProps) => {
   const { event } = useGoogleAnalytics();
-  const { classes, cx } = useStyles();
   const { data: user } = useUser();
   const { data: registration } = useEventRegistration(data.id, preview || !user ? '' : user.user_id);
   const deleteRegistration = useDeleteEventRegistration(data.id);
@@ -210,6 +170,7 @@ const EventRenderer = ({ data, preview = false }: EventRendererProps) => {
     const [notOpenText, setNotOpenText] = useState<string | null>(
       isFuture(userStartRegistrationDate) ? formatDistanceToNowStrict(userStartRegistrationDate, { addSuffix: true, locale: nbLocale }) : null,
     );
+
     useInterval(() => {
       if (isFuture(userStartRegistrationDate)) {
         setNotOpenText(formatDistanceToNowStrict(userStartRegistrationDate, { addSuffix: true, locale: nbLocale }));
@@ -218,46 +179,62 @@ const EventRenderer = ({ data, preview = false }: EventRendererProps) => {
       }
     }, 1000);
 
-    return preview || !data.sign_up ? null : (
-      <>
-        {data.closed ? (
-          <Alert severity='warning' variant='outlined'>
-            Dette arrangementet er stengt. Det er derfor ikke mulig å melde seg av eller på.
-          </Alert>
-        ) : notOpenText ? (
-          <>
-            <HasUnansweredEvaluations />
-            <Button disabled fullWidth variant='contained'>
-              {`Påmelding åpner ${notOpenText}`}
-            </Button>
-          </>
-        ) : !user ? (
-          isFuture(endRegistrationDate) ? (
-            <Button component={Link} fullWidth onClick={() => setLogInRedirectURL(window.location.pathname)} to={URLS.login} variant='contained'>
-              Logg inn for å melde deg på
-            </Button>
-          ) : null
-        ) : registration ? (
-          <RegistrationInfo registration={registration} />
-        ) : isPast(endRegistrationDate) ? null : view === Views.Apply ? (
-          <Button fullWidth onClick={() => setView(Views.Info)} variant='outlined'>
-            Se beskrivelse
-          </Button>
-        ) : data.only_allow_prioritized &&
-          ((data.registration_priorities.length > 0 &&
-            !data.registration_priorities.some((priority) => priority.user_class === user.user_class && priority.user_study === user.user_study)) ||
-            (data.enforces_previous_strikes && user.number_of_strikes >= 3)) ? (
+    if (preview || !data.sign_up) {
+      return null;
+    }
+    if (data.closed) {
+      return (
+        <Alert severity='warning' variant='outlined'>
+          Dette arrangementet er stengt. Det er derfor ikke mulig å melde seg av eller på.
+        </Alert>
+      );
+    }
+    if (notOpenText) {
+      return (
+        <>
+          <HasUnansweredEvaluations />
           <Button disabled fullWidth variant='contained'>
-            Kun åpent for prioriterte
+            {`Påmelding åpner ${notOpenText}`}
           </Button>
-        ) : (
-          <>
-            <HasUnansweredEvaluations />
-            <Button disabled={user?.unanswered_evaluations_count > 0} fullWidth onClick={() => setView(Views.Apply)} variant='contained'>
-              Meld deg på
-            </Button>
-          </>
-        )}
+        </>
+      );
+    }
+    if (!user) {
+      return isFuture(endRegistrationDate) ? (
+        <Button component={Link} fullWidth onClick={() => setLogInRedirectURL(window.location.pathname)} to={URLS.login} variant='contained'>
+          Logg inn for å melde deg på
+        </Button>
+      ) : null;
+    }
+    if (registration) {
+      return <RegistrationInfo registration={registration} />;
+    }
+    if (isPast(endRegistrationDate)) {
+      return null;
+    }
+    if (view === Views.Apply) {
+      return (
+        <Button fullWidth onClick={() => setView(Views.Info)} variant='outlined'>
+          Se beskrivelse
+        </Button>
+      );
+    }
+    const is_prioritized =
+      data.registration_priorities.some((priority) => priority.user_class === user.user_class && priority.user_study === user.user_study) &&
+      (data.enforces_previous_strikes ? user.number_of_strikes < 3 : true);
+    if (data.only_allow_prioritized && data.registration_priorities.length > 0 && !is_prioritized) {
+      return (
+        <Button disabled fullWidth variant='contained'>
+          Kun åpent for prioriterte
+        </Button>
+      );
+    }
+    return (
+      <>
+        <HasUnansweredEvaluations />
+        <Button disabled={user?.unanswered_evaluations_count > 0} fullWidth onClick={() => setView(Views.Apply)} variant='contained'>
+          Meld deg på
+        </Button>
       </>
     );
   };
@@ -282,11 +259,17 @@ const EventRenderer = ({ data, preview = false }: EventRendererProps) => {
               <DetailContent info={formatDate(signOffDeadlineDate)} title='Avmeldingsfrist:' />
             ) : (
               <>
-                {isFuture(startRegistrationDate) && <DetailContent info={formatDate(startRegistrationDate)} title='Start:' />}
-                {isPast(startRegistrationDate) && isFuture(endRegistrationDate) && <DetailContent info={formatDate(endRegistrationDate)} title='Slutt:' />}
+                {isFuture(userStartRegistrationDate) && <DetailContent info={formatDate(startRegistrationDate)} title='Start:' />}
+                {isPast(userStartRegistrationDate) && isFuture(endRegistrationDate) && <DetailContent info={formatDate(endRegistrationDate)} title='Slutt:' />}
               </>
             )}
           </DetailsPaper>
+          {Boolean(data.registration_priorities.length) && (
+            <DetailsPaper noPadding>
+              <DetailsHeader variant='h2'>Prioritert</DetailsHeader>
+              <EventPriorities priorities={data.registration_priorities} />
+            </DetailsPaper>
+          )}
           {data.enforces_previous_strikes ? (
             strikesDelayedRegistrationHours > 0 &&
             isFuture(userStartRegistrationDate) && (
@@ -304,12 +287,6 @@ const EventRenderer = ({ data, preview = false }: EventRendererProps) => {
               Dette arrangementet gir ikke prikker
             </Alert>
           )}
-          {Boolean(data.registration_priorities.length) && (
-            <DetailsPaper noPadding>
-              <DetailsHeader variant='h2'>Prioritert</DetailsHeader>
-              <EventPriorities priorities={data.registration_priorities} />
-            </DetailsPaper>
-          )}
         </>
       )}
       <ApplyInfo />
@@ -319,8 +296,8 @@ const EventRenderer = ({ data, preview = false }: EventRendererProps) => {
   const addToCalendarAnalytics = () => event('add-to-calendar', 'event', `Event: ${data.title}`);
 
   return (
-    <div className={classes.rootGrid}>
-      <div className={classes.infoGrid}>
+    <Stack direction={{ xs: 'column-reverse', lg: 'row' }} gap={1} sx={{ mt: { xs: 1, lg: 2 } }}>
+      <Stack gap={1} sx={{ maxWidth: { lg: 335 } }}>
         {!lgDown && <Info />}
         <ShareButton shareId={data.id} shareType='event' title={data.title} />
         <Button component='a' endIcon={<CalendarIcon />} href={getICSFromEvent(data)} onClick={addToCalendarAnalytics} variant='outlined'>
@@ -332,8 +309,8 @@ const EventRenderer = ({ data, preview = false }: EventRendererProps) => {
             Endre arrangement
           </Button>
         )}
-      </div>
-      <div className={cx(classes.infoGrid, classes.info)}>
+      </Stack>
+      <Stack gap={1}>
         <AspectRatioImg alt={data.image_alt || data.title} borderRadius src={data.image} />
         {lgDown && <Info />}
         <ContentPaper>
@@ -347,40 +324,36 @@ const EventRenderer = ({ data, preview = false }: EventRendererProps) => {
             {user && <EventRegistration event={data} user={user} />}
           </Collapse>
         </ContentPaper>
-      </div>
-    </div>
+      </Stack>
+    </Stack>
   );
 };
 
 export default EventRenderer;
 
-export const EventRendererLoading = () => {
-  const { classes, cx } = useStyles();
-
-  return (
-    <div className={classes.rootGrid}>
-      <div className={classes.infoGrid}>
-        <DetailsPaper noPadding>
-          <DetailContentLoading />
-          <DetailContentLoading />
-          <DetailContentLoading />
-        </DetailsPaper>
-        <DetailsPaper noPadding>
-          <DetailContentLoading />
-          <DetailContentLoading />
-        </DetailsPaper>
-      </div>
-      <div className={cx(classes.infoGrid, classes.info)}>
-        <AspectRatioLoading borderRadius />
-        <ContentPaper>
-          <Skeleton height={80} width='60%' />
-          <Skeleton height={40} width={250} />
-          <Skeleton height={40} width='80%' />
-          <Skeleton height={40} width='85%' />
-          <Skeleton height={40} width='75%' />
-          <Skeleton height={40} width='90%' />
-        </ContentPaper>
-      </div>
-    </div>
-  );
-};
+export const EventRendererLoading = () => (
+  <Stack direction={{ xs: 'column-reverse', lg: 'row' }} gap={1} sx={{ mt: { xs: 1, lg: 2 } }}>
+    <Stack gap={1} sx={{ maxWidth: { lg: 335 } }}>
+      <DetailsPaper noPadding>
+        <DetailContentLoading />
+        <DetailContentLoading />
+        <DetailContentLoading />
+      </DetailsPaper>
+      <DetailsPaper noPadding>
+        <DetailContentLoading />
+        <DetailContentLoading />
+      </DetailsPaper>
+    </Stack>
+    <Stack gap={1}>
+      <AspectRatioLoading borderRadius />
+      <ContentPaper>
+        <Skeleton height={80} width='60%' />
+        <Skeleton height={40} width={250} />
+        <Skeleton height={40} width='80%' />
+        <Skeleton height={40} width='85%' />
+        <Skeleton height={40} width='75%' />
+        <Skeleton height={40} width='90%' />
+      </ContentPaper>
+    </Stack>
+  </Stack>
+);

--- a/src/pages/EventDetails/components/EventRenderer.tsx
+++ b/src/pages/EventDetails/components/EventRenderer.tsx
@@ -297,7 +297,7 @@ const EventRenderer = ({ data, preview = false }: EventRendererProps) => {
 
   return (
     <Stack direction={{ xs: 'column-reverse', lg: 'row' }} gap={1} sx={{ mt: { xs: 1, lg: 2 } }}>
-      <Stack gap={1} sx={{ maxWidth: { lg: 335 } }}>
+      <Stack gap={1} sx={{ width: '100%', maxWidth: { lg: 335 } }}>
         {!lgDown && <Info />}
         <ShareButton shareId={data.id} shareType='event' title={data.title} />
         <Button component='a' endIcon={<CalendarIcon />} href={getICSFromEvent(data)} onClick={addToCalendarAnalytics} variant='outlined'>
@@ -310,7 +310,7 @@ const EventRenderer = ({ data, preview = false }: EventRendererProps) => {
           </Button>
         )}
       </Stack>
-      <Stack gap={1}>
+      <Stack gap={1} sx={{ width: '100%' }}>
         <AspectRatioImg alt={data.image_alt || data.title} borderRadius src={data.image} />
         {lgDown && <Info />}
         <ContentPaper>
@@ -333,7 +333,7 @@ export default EventRenderer;
 
 export const EventRendererLoading = () => (
   <Stack direction={{ xs: 'column-reverse', lg: 'row' }} gap={1} sx={{ mt: { xs: 1, lg: 2 } }}>
-    <Stack gap={1} sx={{ maxWidth: { lg: 335 } }}>
+    <Stack gap={1} sx={{ width: '100%', maxWidth: { lg: 335 } }}>
       <DetailsPaper noPadding>
         <DetailContentLoading />
         <DetailContentLoading />
@@ -344,7 +344,7 @@ export const EventRendererLoading = () => (
         <DetailContentLoading />
       </DetailsPaper>
     </Stack>
-    <Stack gap={1}>
+    <Stack gap={1} sx={{ width: '100%' }}>
       <AspectRatioLoading borderRadius />
       <ContentPaper>
         <Skeleton height={80} width='60%' />

--- a/src/utils.tsx
+++ b/src/utils.tsx
@@ -173,12 +173,6 @@ export const getStrikeReasonAsText = (strikeReason: StrikeReason) => {
 };
 
 /**
- * Add leading zero to numbers below 10. Ex: 2 -> 02, 12 -> 12
- * @param number Number to add zeros to
- */
-// const addLeadingZero = (number: number) => (number < 10 ? '0' + number : number);
-
-/**
  * Format date in format: `Tor 12. okt. 2021 08:30`
  * Year is only shown if it's a different year than this year
  * @param date Date to be formatted
@@ -220,40 +214,6 @@ export const getTimeSince = (date: Date) => {
     return `${days} dager siden`;
   } else {
     return formatDate(date);
-  }
-};
-/**
- * Translate a month of year number to a readable month
- * @param month Month of year
- */
-export const getMonth = (month: number) => {
-  switch (month) {
-    case 0:
-      return 'jan';
-    case 1:
-      return 'feb';
-    case 2:
-      return 'mars';
-    case 3:
-      return 'april';
-    case 4:
-      return 'mai';
-    case 5:
-      return 'juni';
-    case 6:
-      return 'juli';
-    case 7:
-      return 'aug';
-    case 8:
-      return 'sep';
-    case 9:
-      return 'okt';
-    case 10:
-      return 'nov';
-    case 11:
-      return 'des';
-    default:
-      return month;
   }
 };
 


### PR DESCRIPTION
## Description

closes #220 

Changes:
- Påmeldingsknapp teller ned til påmeldingsstart og bytter til "Meld på" automatisk
- Brukere kan se om de er prioritert på et arrangement ved at klassen/studiet er uthevet og det er en tooltip over den ved hovring
- Laster nå inn varsler først når boksen åpnes.
- Varsler oppdateres til read=true kun 1 gang nå, fremdeles når listen over varsler lukkes.
- Fikset feil der en ekstra snackbar ble vist ved deling i nettlesere som ikke støtter ShareAPI
- Refaktorert litt styling

Screenshots:
<img width="466" alt="image" src="https://user-images.githubusercontent.com/31009729/148934926-1de30d5b-a0ea-4f82-9235-885d9f67a62a.png">
<img width="369" alt="image" src="https://user-images.githubusercontent.com/31009729/148935256-efecc147-1d16-4545-91f7-d54a2f9beb2b.png">

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [x] The PR includes a `closes #issueID`
- [x] The PR includes a picture showing visual changes
- [x] Added Google Analytics tracking if relevant
- [x] Pull request title follows [conventional commits](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) (`type(scope): description`)
- [x] CHANGELOG.md has been updated. [Guide](https://tihlde.slab.com/posts/changelog-z8hybjom)
