### PR TITLE
feat(stories): shows continuously hiring in stories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@
 
 ## Neste versjon
 
+- 🦟 **Stories**. Annonser som har fortløpende opptak vises med "fortløpende opptak".
+
 ## Versjon 1.4.1 (15.01.2022)
 
 - ⚡ **Arrangementer**. Brukere kan nå se om de er prioritert på et arrangement.

--- a/src/components/story/Story.tsx
+++ b/src/components/story/Story.tsx
@@ -155,7 +155,7 @@ const Story = ({ items, fadeColor }: StoryProps) => {
         newItems.push({
           ...newItem,
           link: `${URLS.jobposts}${item.id}/${urlEncode(item.title)}/`,
-          description: `Bedrift: ${item.company} \n Når: ${formatDate(parseISO(item.deadline))}`,
+          description: `Bedrift: ${item.company} \n ${item.is_continuously_hiring ? 'Fortløpende opptak' : `Når: ${formatDate(parseISO(item.deadline))}`}`,
           topText: 'Annonse',
         });
       } else if (instanceOfNews(item)) {


### PR DESCRIPTION
## Description
Viser annonser markert med fortløpende opptak med "Fortløpende opptak" og ikke dato annonsen går ut.

closes #312

Changes:

Screenshots:
<img width="1172" alt="Skjermbilde 2022-01-27 kl  17 15 56" src="https://user-images.githubusercontent.com/26656069/151398842-8bde557d-d430-46f3-b0ba-08e46a129ba9.png">


## Pull request checklist

Please check if your PR fulfills the following requirements:

- [x] The PR includes a `closes #issueID`
- [x] The PR includes a picture showing visual changes
- [ ] Added Google Analytics tracking if relevant
- [x] Pull request title follows [conventional commits](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) (`type(scope): description`)
- [ ] CHANGELOG.md has been updated. [Guide](https://tihlde.slab.com/posts/changelog-z8hybjom)
