### PR TITLE
Fix(eventadmin):show that event is closed in eventadmin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@
 
 ## Neste versjon
 
+- 🦟 **Eventadmin**. Viser at et arrangement er stengt i adminpanelet.
+
 ## Versjon 1.4.1 (15.01.2022)
 
 - ⚡ **Arrangementer**. Brukere kan nå se om de er prioritert på et arrangement.

--- a/src/components/layout/SidebarList.tsx
+++ b/src/components/layout/SidebarList.tsx
@@ -17,15 +17,15 @@ import {
   Divider,
   IconButton,
   Skeleton,
+  ListItemIcon,
 } from '@mui/material';
 
 // Icons
 import MenuIcon from '@mui/icons-material/FormatListBulletedRounded';
 import AddIcon from '@mui/icons-material/AddRounded';
-
+import PauseCircle from '@mui/icons-material/PauseCircle';
 // Project components
 import Pagination from 'components/layout/Pagination';
-
 const useStyles = makeStyles()((theme) => ({
   header: {
     display: 'flex',
@@ -76,6 +76,7 @@ export type SidebarListProps<Type> = {
   onItemClick: (itemId: null | number) => void;
   selectedItemId: number;
   title: string;
+  closedKey?: keyof Type;
   noExpired?: boolean;
   idKey: keyof Type;
   titleKey: keyof Type;
@@ -93,6 +94,7 @@ const SidebarList = <Type extends unknown>({
   title,
   idKey,
   titleKey,
+  closedKey,
   descKey,
   formatDesc,
   noExpired = false,
@@ -132,6 +134,11 @@ const SidebarList = <Type extends unknown>({
       className={classes.listItem}
       onClick={() => handleItemClick(Number(item[idKey]))}
       selected={Boolean(Number(item[idKey]) === selectedItemId)}>
+      {closedKey && item[closedKey] && (
+        <ListItemIcon>
+          <PauseCircle color='warning' />
+        </ListItemIcon>
+      )}
       <ListItemText
         classes={{ secondary: classes.listItemSecondary }}
         primary={item[titleKey]}

--- a/src/components/layout/SidebarList.tsx
+++ b/src/components/layout/SidebarList.tsx
@@ -17,13 +17,12 @@ import {
   Divider,
   IconButton,
   Skeleton,
-  ListItemIcon,
 } from '@mui/material';
 
 // Icons
 import MenuIcon from '@mui/icons-material/FormatListBulletedRounded';
 import AddIcon from '@mui/icons-material/AddRounded';
-import WarningAmber from '@mui/icons-material/WarningAmber';
+
 // Project components
 import Pagination from 'components/layout/Pagination';
 const useStyles = makeStyles()((theme) => ({
@@ -76,7 +75,6 @@ export type SidebarListProps<Type> = {
   onItemClick: (itemId: null | number) => void;
   selectedItemId: number;
   title: string;
-  closedKey?: keyof Type;
   noExpired?: boolean;
   idKey: keyof Type;
   titleKey: keyof Type;
@@ -94,7 +92,6 @@ const SidebarList = <Type extends unknown>({
   title,
   idKey,
   titleKey,
-  closedKey,
   descKey,
   formatDesc,
   noExpired = false,
@@ -139,11 +136,6 @@ const SidebarList = <Type extends unknown>({
         primary={item[titleKey]}
         secondary={formatDesc ? formatDesc(item[descKey]) : item[descKey]}
       />
-      {closedKey && !expiredItems.includes(item) && item[closedKey] && (
-        <ListItemIcon>
-          <WarningAmber color='warning' />
-        </ListItemIcon>
-      )}
     </MuiListItem>
   );
   const ListItemLoading = () => (

--- a/src/components/layout/SidebarList.tsx
+++ b/src/components/layout/SidebarList.tsx
@@ -134,16 +134,16 @@ const SidebarList = <Type extends unknown>({
       className={classes.listItem}
       onClick={() => handleItemClick(Number(item[idKey]))}
       selected={Boolean(Number(item[idKey]) === selectedItemId)}>
-      {closedKey && item[closedKey] && (
-        <ListItemIcon>
-          <PauseCircle color='warning' />
-        </ListItemIcon>
-      )}
       <ListItemText
         classes={{ secondary: classes.listItemSecondary }}
         primary={item[titleKey]}
         secondary={formatDesc ? formatDesc(item[descKey]) : item[descKey]}
       />
+      {closedKey && !expiredItems.includes(item) && item[closedKey] && (
+        <ListItemIcon>
+          <PauseCircle color='warning' />
+        </ListItemIcon>
+      )}
     </MuiListItem>
   );
   const ListItemLoading = () => (

--- a/src/components/layout/SidebarList.tsx
+++ b/src/components/layout/SidebarList.tsx
@@ -23,7 +23,7 @@ import {
 // Icons
 import MenuIcon from '@mui/icons-material/FormatListBulletedRounded';
 import AddIcon from '@mui/icons-material/AddRounded';
-import PauseCircle from '@mui/icons-material/PauseCircle';
+import WarningAmber from '@mui/icons-material/WarningAmber';
 // Project components
 import Pagination from 'components/layout/Pagination';
 const useStyles = makeStyles()((theme) => ({
@@ -141,7 +141,7 @@ const SidebarList = <Type extends unknown>({
       />
       {closedKey && !expiredItems.includes(item) && item[closedKey] && (
         <ListItemIcon>
-          <PauseCircle color='warning' />
+          <WarningAmber color='warning' />
         </ListItemIcon>
       )}
     </MuiListItem>

--- a/src/pages/EventAdministration/components/EventEditor.tsx
+++ b/src/pages/EventAdministration/components/EventEditor.tsx
@@ -484,6 +484,7 @@ const EventEditor = ({ eventId, goToEvent }: EventEditorProps) => {
                 closeText='Ikke steng arrangementet'
                 color='warning'
                 contentText='Å stenge et arrangement kan ikke reverseres. Eventuell på- og avmelding vil bli stoppet.'
+                disabled={data?.closed}
                 onConfirm={closeEvent}
                 titleText='Er du sikker?'>
                 Steng

--- a/src/pages/EventAdministration/index.tsx
+++ b/src/pages/EventAdministration/index.tsx
@@ -7,7 +7,7 @@ import { formatDate } from 'utils';
 
 // Material-UI
 import { makeStyles } from 'makeStyles';
-import { Typography, Collapse } from '@mui/material';
+import { Typography, Collapse, Alert } from '@mui/material';
 
 // Icons
 import EditIcon from '@mui/icons-material/EditRounded';
@@ -98,6 +98,7 @@ const EventAdministration = () => {
       />
       <div className={classes.root}>
         <div className={classes.content}>
+          {event && event.closed && <Alert severity='warning'>Dette arrangementet er stengt.</Alert>}
           <Typography className={classes.header} variant='h2'>
             {eventId ? 'Endre arrangement' : 'Nytt arrangement'}
           </Typography>

--- a/src/pages/EventAdministration/index.tsx
+++ b/src/pages/EventAdministration/index.tsx
@@ -86,7 +86,6 @@ const EventAdministration = () => {
       maxWidth={false}
       options={{ lightColor: 'blue', filledTopbar: true, gutterBottom: true, gutterTop: true, noFooter: true, title: 'Admin arrangementer' }}>
       <SidebarList
-        closedKey='closed'
         descKey='start_date'
         formatDesc={(desc) => formatDate(parseISO(desc))}
         idKey='id'
@@ -98,7 +97,11 @@ const EventAdministration = () => {
       />
       <div className={classes.root}>
         <div className={classes.content}>
-          {event && event.closed && <Alert severity='warning'>Dette arrangementet er stengt.</Alert>}
+          {event && event.closed && (
+            <Alert severity='warning' sx={{ mb: 1 }}>
+              Dette arrangementet er stengt.
+            </Alert>
+          )}
           <Typography className={classes.header} variant='h2'>
             {eventId ? 'Endre arrangement' : 'Nytt arrangement'}
           </Typography>

--- a/src/pages/EventAdministration/index.tsx
+++ b/src/pages/EventAdministration/index.tsx
@@ -86,6 +86,7 @@ const EventAdministration = () => {
       maxWidth={false}
       options={{ lightColor: 'blue', filledTopbar: true, gutterBottom: true, gutterTop: true, noFooter: true, title: 'Admin arrangementer' }}>
       <SidebarList
+        closedKey='closed'
         descKey='start_date'
         formatDesc={(desc) => formatDate(parseISO(desc))}
         idKey='id'

--- a/src/types/Event.tsx
+++ b/src/types/Event.tsx
@@ -43,7 +43,7 @@ export interface Event {
 export type EventRequired = Partial<Event> & Pick<Event, 'end_date' | 'title' | 'start_date'> & { organizer: Group['slug'] };
 export type EventCompact = Pick<
   Event,
-  'category' | 'end_date' | 'expired' | 'organizer' | 'id' | 'image' | 'image_alt' | 'location' | 'title' | 'start_date' | 'updated_at'
+  'category' | 'end_date' | 'expired' | 'organizer' | 'id' | 'image' | 'image_alt' | 'location' | 'title' | 'start_date' | 'updated_at' | 'closed'
 >;
 
 export interface RegistrationPriority {

--- a/src/types/Event.tsx
+++ b/src/types/Event.tsx
@@ -43,7 +43,7 @@ export interface Event {
 export type EventRequired = Partial<Event> & Pick<Event, 'end_date' | 'title' | 'start_date'> & { organizer: Group['slug'] };
 export type EventCompact = Pick<
   Event,
-  'category' | 'end_date' | 'expired' | 'organizer' | 'id' | 'image' | 'image_alt' | 'location' | 'title' | 'start_date' | 'updated_at' | 'closed'
+  'category' | 'end_date' | 'expired' | 'organizer' | 'id' | 'image' | 'image_alt' | 'location' | 'title' | 'start_date' | 'updated_at'
 >;
 
 export interface RegistrationPriority {


### PR DESCRIPTION
## Description
Viser at et arrangement er stengt i eventadmin. Dette vises både i sidepanelet med ett icon og på selve arrangementet i adminpanelet. Denne ble laget i sammenheng med denne pull requesten fra backend https://github.com/TIHLDE/Lepton/pull/401. (Det går hent fint å kjøre denne uten oppdateringen fra backend, men da vises ikke iconet i sidepanelet.)

Ved å vise et klart icon i sidepanelet kan adminbrukere tydelig se hvilke arrangementer som er stengt uten å klikke på dem. 

closes #313

Changes:

Screenshots:
<img width="1440" alt="Skjermbilde 2022-01-27 kl  19 01 01" src="https://user-images.githubusercontent.com/26656069/151417370-54e0fb00-6dec-4f96-b0b4-ee3e4fa29cf2.png">

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [x] The PR includes a `closes #issueID`
- [x] The PR includes a picture showing visual changes
- [ ] Added Google Analytics tracking if relevant
- [x] Pull request title follows [conventional commits](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) (`type(scope): description`)
- [x] CHANGELOG.md has been updated. [Guide](https://tihlde.slab.com/posts/changelog-z8hybjom)
