### PR TITLE
feat(image-upload): showing preferred image ratio

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 ## Neste versjon
 
 - ✨ **Skjemamaler**. Administratorer kan nå lage maler som man kan ta utgangspunkt i når man lager et nytt skjema.
+- ✨ **Bildeopplastning**. Viser foretrukket størrelsesforhold på bilder ved bildeopplastning.
 
 ## Versjon 1.4.2 (31.01.2022)
 

--- a/src/components/inputs/Upload.tsx
+++ b/src/components/inputs/Upload.tsx
@@ -60,7 +60,7 @@ export type ImageUploadProps<FormValues extends FieldValues = FieldValues> = But
   Pick<UseFormReturn<FormValues>, 'formState' | 'watch' | 'setValue'> & {
     register: UseFormRegisterReturn;
     label?: string;
-    ratio?: number;
+    ratio?: `${number}:${number}`;
   };
 
 export const GenericImageUpload = <FormValues extends FieldValues>({
@@ -84,7 +84,10 @@ export const GenericImageUpload = <FormValues extends FieldValues>({
   const [zoom, setZoom] = useState(1);
   const [imageFile, setImageFile] = useState<File | undefined>(undefined);
   const [croppedAreaPixels, setCroppedAreaPixels] = useState(null);
-
+  const ratioFloat = ratio
+    ?.split(':')
+    .map((value) => parseInt(value))
+    .reduce((previousValue, currentValue) => previousValue / currentValue);
   const closeDialog = () => {
     setDialogOpen(false);
     setImageSrc('');
@@ -167,9 +170,20 @@ export const GenericImageUpload = <FormValues extends FieldValues>({
         onConfirm={() => dialogConfirmCrop()}
         open={dialogOpen}
         titleText='Tilpass bildet'>
-        <CropperWrapper>
-          <Cropper aspect={ratio} crop={crop} image={imageSrc} onCropChange={setCrop} onCropComplete={onCropComplete} onZoomChange={setZoom} zoom={zoom} />
-        </CropperWrapper>
+        <>
+          <CropperWrapper>
+            <Cropper
+              aspect={ratioFloat}
+              crop={crop}
+              image={imageSrc}
+              onCropChange={setCrop}
+              onCropComplete={onCropComplete}
+              onZoomChange={setZoom}
+              zoom={zoom}
+            />
+          </CropperWrapper>
+          <Typography textAlign='center'>Bildet bør være på formatet: {ratio}</Typography>
+        </>
         {isLoading && <LinearProgress />}
       </Dialog>
     </>

--- a/src/components/inputs/Upload.tsx
+++ b/src/components/inputs/Upload.tsx
@@ -86,7 +86,7 @@ export const GenericImageUpload = <FormValues extends FieldValues>({
   const [croppedAreaPixels, setCroppedAreaPixels] = useState(null);
   const ratioFloat = ratio
     ?.split(':')
-    .map((value) => parseInt(value))
+    .map(Number)
     .reduce((previousValue, currentValue) => previousValue / currentValue);
   const closeDialog = () => {
     setDialogOpen(false);
@@ -182,7 +182,7 @@ export const GenericImageUpload = <FormValues extends FieldValues>({
               zoom={zoom}
             />
           </CropperWrapper>
-          <Typography textAlign='center'>Bildet bør være på formatet: {ratio}</Typography>
+          <Typography textAlign='center'>Anbefalt størrelsesforhold: {ratio}</Typography>
         </>
         {isLoading && <LinearProgress />}
       </Dialog>

--- a/src/pages/EventAdministration/components/EventEditor.tsx
+++ b/src/pages/EventAdministration/components/EventEditor.tsx
@@ -428,7 +428,7 @@ const EventEditor = ({ eventId, goToEvent }: EventEditorProps) => {
             </Stack>
           </Collapse>
           <MarkdownEditor formState={formState} {...register('description', { required: 'Gi arrangementet en beskrivelse' })} required />
-          <ImageUpload formState={formState} label='Velg bilde' ratio={21 / 9} register={register('image')} setValue={setValue} watch={watch} />
+          <ImageUpload formState={formState} label='Velg bilde' ratio='21:9' register={register('image')} setValue={setValue} watch={watch} />
           <TextField formState={formState} label='Bildetekst' {...register('image_alt')} />
           <div className={classes.grid}>
             {groupOptions.length > 0 && (

--- a/src/pages/EventAdministration/components/EventFormAdmin.tsx
+++ b/src/pages/EventAdministration/components/EventFormAdmin.tsx
@@ -1,6 +1,6 @@
 import { EventFormCreate, Form, FormCreate } from 'types';
 import { EventFormType, FormResourceType } from 'types/Enums';
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { useEventById } from 'hooks/Event';
 import { useForm } from 'react-hook-form';
 import { Typography, LinearProgress, Stack, Button } from '@mui/material';

--- a/src/pages/JobPostAdministration/components/JobPostEditor.tsx
+++ b/src/pages/JobPostAdministration/components/JobPostEditor.tsx
@@ -193,7 +193,7 @@ const JobPostEditor = ({ jobpostId, goToJobPost }: EventEditorProps) => {
             />
             <TextField formState={formState} label='Link' {...register('link')} />
           </div>
-          <ImageUpload formState={formState} label='Velg logo' ratio={21 / 9} register={register('image')} setValue={setValue} watch={watch} />
+          <ImageUpload formState={formState} label='Velg logo' ratio='21:9' register={register('image')} setValue={setValue} watch={watch} />
           <TextField formState={formState} label='Alternativ bildetekst' {...register('image_alt')} />
           <div className={classes.grid}>
             <TextField formState={formState} label='Bedrift' {...register('company', { required: 'Du må oppgi en bedrift' })} required />

--- a/src/pages/NewsAdministration/components/NewsEditor.tsx
+++ b/src/pages/NewsAdministration/components/NewsEditor.tsx
@@ -132,7 +132,7 @@ const NewsEditor = ({ newsId, goToNews }: NewsEditorProps) => {
           <TextField formState={formState} label='Tittel' {...register('title', { required: 'Feltet er påkrevd' })} required />
           <TextField formState={formState} label='Header' {...register('header', { required: 'Feltet er påkrevd' })} required />
           <MarkdownEditor formState={formState} label='Innhold' {...register('body', { required: 'Gi nyheten et innhold' })} required />
-          <ImageUpload formState={formState} label='Velg bilde' ratio={21 / 9} register={register('image')} setValue={setValue} watch={watch} />
+          <ImageUpload formState={formState} label='Velg bilde' ratio='21:9' register={register('image')} setValue={setValue} watch={watch} />
           <TextField formState={formState} label='Alternativ bildetekst' {...register('image_alt')} />
           <RendererPreview className={classes.margin} getContent={getNewsPreview} renderer={NewsRenderer} />
           <SubmitButton className={classes.margin} disabled={isUpdating} formState={formState}>

--- a/src/pages/Profile/components/ProfileSettings.tsx
+++ b/src/pages/Profile/components/ProfileSettings.tsx
@@ -73,7 +73,7 @@ const ProfileSettings = ({ isAdmin, user }: ProfileSettingsProps) => {
           </div>
         )}
         <TextField disabled={updateUser.isLoading} formState={formState} InputProps={{ type: 'number' }} label='Telefon' {...register('cell')} />
-        <ImageUpload formState={formState} label='Velg profilbilde' ratio={1} register={register('image')} setValue={setValue} watch={watch} />
+        <ImageUpload formState={formState} label='Velg profilbilde' ratio='1:1' register={register('image')} setValue={setValue} watch={watch} />
         <div className={classes.selectGrid}>
           <Select control={control} disabled={!isAdmin} formState={formState} label='Studie' name='user_study'>
             {[1, 2, 3, 4, 5, 6].map((i) => (


### PR DESCRIPTION
## Description
Viser brukeren hva som er foretrukket størrelsesforhold på et bilde når de laster det opp.

closes #338 

Changes:

Screenshots:
<img width="1046" alt="Skjermbilde 2022-02-01 kl  17 08 56" src="https://user-images.githubusercontent.com/26656069/152005319-0884d739-bf37-4705-8171-7af18812513b.png">


## Pull request checklist

Please check if your PR fulfills the following requirements:

- [x] The PR includes a `closes #issueID`
- [x] The PR includes a picture showing visual changes
- [ ] Added Google Analytics tracking if relevant
- [x] Pull request title follows [conventional commits](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) (`type(scope): description`)
- [x] CHANGELOG.md has been updated. [Guide](https://tihlde.slab.com/posts/changelog-z8hybjom)
