### PR TITLE
fix(news): not all news needs a creator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 ## Neste versjon
 
+- 🦟 **Nyheter**. Nyheter trenger ikke å ha forfatter.
 - ✨ **Galleri**. Lagt til digitalt fotoalbum for arrangementer.
 
 ## Versjon 2022.03.13

--- a/src/pages/NewsAdministration/components/NewsEditor.tsx
+++ b/src/pages/NewsAdministration/components/NewsEditor.tsx
@@ -104,7 +104,7 @@ const NewsEditor = ({ newsId, goToNews }: NewsEditorProps) => {
   const submit = async (data: FormValues) => {
     newsId
       ? updateNews.mutate(
-          { ...data, creator: data.creator?.user_id || '' },
+          { ...data, creator: data.creator?.user_id || null },
           {
             onSuccess: () => {
               showSnackbar('Nyheten ble oppdatert', 'success');

--- a/src/pages/NewsAdministration/components/NewsEditor.tsx
+++ b/src/pages/NewsAdministration/components/NewsEditor.tsx
@@ -115,7 +115,7 @@ const NewsEditor = ({ newsId, goToNews }: NewsEditorProps) => {
           },
         )
       : createNews.mutate(
-          { ...data, creator: data.creator?.user_id || '' },
+          { ...data, creator: data.creator?.user_id || null },
           {
             onSuccess: (newNewsItem) => {
               showSnackbar('Nyheten ble opprettet', 'success');

--- a/src/types/News.tsx
+++ b/src/types/News.tsx
@@ -2,7 +2,7 @@ import { UserBase } from 'types/User';
 
 export type NewsRequired = Omit<Partial<News>, 'creator'> &
   Pick<News, 'title' | 'header' | 'body'> & {
-    creator: UserBase['user_id'];
+    creator: UserBase['user_id'] | null;
   };
 
 export type News = {


### PR DESCRIPTION
## Description
Nå er det mulig å endre og opprette nyheter uten forfatter

closes #445

Changes:

Screenshots:

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] The PR includes a picture showing visual changes
- [ ] Added Analytics-events if relevant
- [x] CHANGELOG.md has been updated. [Guide](https://tihlde.slab.com/posts/changelog-z8hybjom)
