### PR TITLE
fix(fines): Made button action more intuitive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 
 - 🦟 **Nyheter**. Nyheter trenger ikke å ha forfatter.
 - ✨ **Galleri**. Lagt til digitalt fotoalbum for arrangementer.
+- 🎨 **Botsystem**. Endret tittelen på enkelte knapper slik at de beskriver hva knappen gjør.
 
 ## Versjon 2022.03.13
 

--- a/src/pages/Groups/fines/FineItem.tsx
+++ b/src/pages/Groups/fines/FineItem.tsx
@@ -1,8 +1,5 @@
 import PaidIcon from '@mui/icons-material/CreditScoreRounded';
-import GavelIcon from '@mui/icons-material/Gavel';
 import Delete from '@mui/icons-material/DeleteRounded';
-import TimeIcon from '@mui/icons-material/AccessTime';
-import HelpIcon from '@mui/icons-material/HelpCenter';
 import ApprovedIcon from '@mui/icons-material/DoneOutlineRounded';
 import EditRounded from '@mui/icons-material/EditRounded';
 import ExpandLessIcon from '@mui/icons-material/ExpandLessRounded';
@@ -111,15 +108,15 @@ const FineItem = ({ fine, groupSlug, isAdmin, hideUserInfo, ...props }: FineItem
       <Collapse in={expanded}>
         <Divider />
         <Stack gap={1} sx={{ p: [1, undefined, 2] }}>
-          <Stack direction={{ xs: 'column', md: 'row' }} gap={1}>
-            {fine.reason && <Chip icon={<HelpIcon />} label={fine.reason} variant='outlined' />}
-            <Chip icon={<GavelIcon />} label={`${fine.created_by.first_name} ${fine.created_by.last_name}`} variant='outlined' />
-            <Chip icon={<TimeIcon />} label={`${formatDate(parseISO(fine.created_at), { fullDayOfWeek: true, fullMonth: true })}`} variant='outlined' />
+          <Stack direction='row' gap={1}>
+            <Chip color={fine.approved ? 'success' : 'error'} icon={<ApprovedIcon />} label={fine.approved ? 'Godkjent' : 'Ikke godkjent'} variant='outlined' />
+            <Chip color={fine.payed ? 'success' : 'error'} icon={<PaidIcon />} label={fine.payed ? 'Betalt' : 'Ikke betalt'} variant='outlined' />
           </Stack>
-          <Stack direction={{ xs: 'column', md: 'row' }} gap={1}>
-            <Chip icon={<ApprovedIcon />} label={fine.approved ? 'Godkjent' : 'Ikke godkjent'} variant='outlined' />
-            <Chip icon={<PaidIcon />} label={fine.payed ? 'Betalt' : 'Ikke betalt'} variant='outlined' />
-          </Stack>
+          <div>
+            {fine.reason && <Typography variant='subtitle2'>{`Begrunnelse: ${fine.reason}`}</Typography>}
+            <Typography variant='subtitle2'>{`Opprettet av: ${fine.created_by.first_name} ${fine.created_by.last_name}`}</Typography>
+            <Typography variant='subtitle2'>{`Dato: ${formatDate(parseISO(fine.created_at), { fullDayOfWeek: true, fullMonth: true })}`}</Typography>
+          </div>
           {isAdmin && (
             <>
               <Stack direction={{ xs: 'column', md: 'row' }} gap={1}>
@@ -129,8 +126,8 @@ const FineItem = ({ fine, groupSlug, isAdmin, hideUserInfo, ...props }: FineItem
                   fullWidth
                   onClick={toggleApproved}
                   startIcon={<ApprovedIcon />}
-                  variant='outlined'>
-                  {fine.approved ? 'Merk som ikke godkjent' : 'Merk som godkjent'}
+                  variant='contained'>
+                  Merk som {fine.approved ? 'ikke godkjent' : 'godkjent'}
                 </Button>
                 <Button
                   color={fine.payed ? 'error' : 'success'}
@@ -138,8 +135,8 @@ const FineItem = ({ fine, groupSlug, isAdmin, hideUserInfo, ...props }: FineItem
                   fullWidth
                   onClick={togglePayed}
                   startIcon={<PaidIcon />}
-                  variant='outlined'>
-                  {fine.payed ? 'Merk som ubetalt' : 'Merk som betalt'}
+                  variant='contained'>
+                  Merk som {fine.payed ? 'ikke betalt' : 'betalt'}
                 </Button>
               </Stack>
               <Dialog onClose={() => setEditOpen(false)} open={editOpen} titleText='Endre bot'>

--- a/src/pages/Groups/fines/FineItem.tsx
+++ b/src/pages/Groups/fines/FineItem.tsx
@@ -1,10 +1,13 @@
-import PayedIcon from '@mui/icons-material/CreditScoreRounded';
+import PaidIcon from '@mui/icons-material/CreditScoreRounded';
+import GavelIcon from '@mui/icons-material/Gavel';
 import Delete from '@mui/icons-material/DeleteRounded';
+import TimeIcon from '@mui/icons-material/AccessTime';
+import HelpIcon from '@mui/icons-material/HelpCenter';
 import ApprovedIcon from '@mui/icons-material/DoneOutlineRounded';
 import EditRounded from '@mui/icons-material/EditRounded';
 import ExpandLessIcon from '@mui/icons-material/ExpandLessRounded';
 import ExpandMoreIcon from '@mui/icons-material/ExpandMoreRounded';
-import { Button, Checkbox, Collapse, Divider, ListItem, ListItemButton, ListItemProps, ListItemText, Stack, Tooltip, Typography } from '@mui/material';
+import { Button, Checkbox, Chip, Collapse, Divider, ListItem, ListItemButton, ListItemProps, ListItemText, Stack, Tooltip, Typography } from '@mui/material';
 import { parseISO } from 'date-fns';
 import { useState } from 'react';
 import { useForm } from 'react-hook-form';
@@ -89,26 +92,34 @@ const FineItem = ({ fine, groupSlug, isAdmin, hideUserInfo, ...props }: FineItem
             {fine.amount}
           </Typography>
           <ListItemText
-            primary={<>{hideUserInfo ? fine.description : `${fine.user.first_name} ${fine.user.last_name}`}</>}
+            primary={
+              <>
+                {hideUserInfo ? fine.description : `${fine.user.first_name} ${fine.user.last_name}`}
+                <Tooltip title={`Boten er ${fine.approved ? '' : 'ikke '} godkjent`}>
+                  <ApprovedIcon color={fine.approved ? 'success' : 'error'} sx={{ fontSize: 'inherit', ml: 0.5, mb: '-1px' }} />
+                </Tooltip>
+                <Tooltip title={`Boten er ${fine.payed ? '' : 'ikke '} betalt`}>
+                  <PaidIcon color={fine.payed ? 'success' : 'error'} sx={{ fontSize: 'inherit', ml: 0.5, mb: '-1px' }} />
+                </Tooltip>
+              </>
+            }
             secondary={hideUserInfo ? formatDate(parseISO(fine.created_at), { fullDayOfWeek: true, fullMonth: true }) : fine.description}
           />
-          <Tooltip title={`Boten er ${fine.approved ? '' : 'ikke '} godkjent`}>
-            <ApprovedIcon color={fine.approved ? 'success' : 'error'} sx={{ fontSize: '1.5em', mr: 1 }} />
-          </Tooltip>
-          <Tooltip title={`Boten er ${fine.payed ? '' : 'ikke '} betalt`}>
-            <PayedIcon color={fine.payed ? 'success' : 'error'} sx={{ fontSize: '1.5em', mr: 1 }} />
-          </Tooltip>
           {expanded ? <ExpandLessIcon /> : <ExpandMoreIcon />}
         </ListItemButton>
       </ListItem>
       <Collapse in={expanded}>
         <Divider />
         <Stack gap={1} sx={{ p: [1, undefined, 2] }}>
-          <div>
-            {fine.reason && <Typography variant='subtitle2'>{`Begrunnelse: ${fine.reason}`}</Typography>}
-            <Typography variant='subtitle2'>{`Opprettet av: ${fine.created_by.first_name} ${fine.created_by.last_name}`}</Typography>
-            <Typography variant='subtitle2'>{`Dato: ${formatDate(parseISO(fine.created_at), { fullDayOfWeek: true, fullMonth: true })}`}</Typography>
-          </div>
+          <Stack direction={{ xs: 'column', md: 'row' }} gap={1}>
+            {fine.reason && <Chip icon={<HelpIcon />} label={fine.reason} variant='outlined' />}
+            <Chip icon={<GavelIcon />} label={`${fine.created_by.first_name} ${fine.created_by.last_name}`} variant='outlined' />
+            <Chip icon={<TimeIcon />} label={`${formatDate(parseISO(fine.created_at), { fullDayOfWeek: true, fullMonth: true })}`} variant='outlined' />
+          </Stack>
+          <Stack direction={{ xs: 'column', md: 'row' }} gap={1}>
+            <Chip icon={<ApprovedIcon />} label={fine.approved ? 'Godkjent' : 'Ikke godkjent'} variant='outlined' />
+            <Chip icon={<PaidIcon />} label={fine.payed ? 'Betalt' : 'Ikke betalt'} variant='outlined' />
+          </Stack>
           {isAdmin && (
             <>
               <Stack direction={{ xs: 'column', md: 'row' }} gap={1}>
@@ -126,7 +137,7 @@ const FineItem = ({ fine, groupSlug, isAdmin, hideUserInfo, ...props }: FineItem
                   disabled={!fine.approved}
                   fullWidth
                   onClick={togglePayed}
-                  startIcon={<PayedIcon />}
+                  startIcon={<PaidIcon />}
                   variant='outlined'>
                   {fine.payed ? 'Merk som ubetalt' : 'Merk som betalt'}
                 </Button>

--- a/src/pages/Groups/fines/FineItem.tsx
+++ b/src/pages/Groups/fines/FineItem.tsx
@@ -89,19 +89,15 @@ const FineItem = ({ fine, groupSlug, isAdmin, hideUserInfo, ...props }: FineItem
             {fine.amount}
           </Typography>
           <ListItemText
-            primary={
-              <>
-                {hideUserInfo ? fine.description : `${fine.user.first_name} ${fine.user.last_name}`}
-                <Tooltip title={`Boten er ${fine.approved ? '' : 'ikke '} godkjent`}>
-                  <ApprovedIcon color={fine.approved ? 'success' : 'error'} sx={{ fontSize: 'inherit', ml: 0.5, mb: '-1px' }} />
-                </Tooltip>
-                <Tooltip title={`Boten er ${fine.payed ? '' : 'ikke '} betalt`}>
-                  <PayedIcon color={fine.payed ? 'success' : 'error'} sx={{ fontSize: 'inherit', ml: 0.5, mb: '-1px' }} />
-                </Tooltip>
-              </>
-            }
+            primary={<>{hideUserInfo ? fine.description : `${fine.user.first_name} ${fine.user.last_name}`}</>}
             secondary={hideUserInfo ? formatDate(parseISO(fine.created_at), { fullDayOfWeek: true, fullMonth: true }) : fine.description}
           />
+          <Tooltip title={`Boten er ${fine.approved ? '' : 'ikke '} godkjent`}>
+            <ApprovedIcon color={fine.approved ? 'success' : 'error'} sx={{ fontSize: '1.5em', mr: 1 }} />
+          </Tooltip>
+          <Tooltip title={`Boten er ${fine.payed ? '' : 'ikke '} betalt`}>
+            <PayedIcon color={fine.payed ? 'success' : 'error'} sx={{ fontSize: '1.5em', mr: 1 }} />
+          </Tooltip>
           {expanded ? <ExpandLessIcon /> : <ExpandMoreIcon />}
         </ListItemButton>
       </ListItem>
@@ -117,22 +113,22 @@ const FineItem = ({ fine, groupSlug, isAdmin, hideUserInfo, ...props }: FineItem
             <>
               <Stack direction={{ xs: 'column', md: 'row' }} gap={1}>
                 <Button
-                  color={fine.approved ? 'success' : 'error'}
+                  color={fine.approved ? 'error' : 'success'}
                   disabled={fine.payed}
                   fullWidth
                   onClick={toggleApproved}
                   startIcon={<ApprovedIcon />}
-                  variant='contained'>
-                  {fine.approved ? 'Godkjent' : 'Ikke godkjent'}
+                  variant='outlined'>
+                  {fine.approved ? 'Merk som ikke godkjent' : 'Merk som godkjent'}
                 </Button>
                 <Button
-                  color={fine.payed ? 'success' : 'error'}
+                  color={fine.payed ? 'error' : 'success'}
                   disabled={!fine.approved}
                   fullWidth
                   onClick={togglePayed}
                   startIcon={<PayedIcon />}
-                  variant='contained'>
-                  {fine.payed ? 'Betalt' : 'Ikke betalt'}
+                  variant='outlined'>
+                  {fine.payed ? 'Merk som ubetalt' : 'Merk som betalt'}
                 </Button>
               </Stack>
               <Dialog onClose={() => setEditOpen(false)} open={editOpen} titleText='Endre bot'>

--- a/src/pages/Groups/fines/index.tsx
+++ b/src/pages/Groups/fines/index.tsx
@@ -3,6 +3,7 @@ import { useEffect, useMemo, useState } from 'react';
 import { useParams } from 'react-router-dom';
 
 import { useGroup, useGroupFines, useGroupFinesStatistics, useGroupUsersFines } from 'hooks/Group';
+import { useMemberships } from 'hooks/Membership';
 import { useUser } from 'hooks/User';
 
 import AddFineDialog from 'pages/Groups/fines/AddFineDialog';
@@ -31,6 +32,7 @@ const Fines = () => {
   const { slug } = useParams<'slug'>();
   const { data: user } = useUser();
   const { data: group } = useGroup(slug || '-');
+  const { data: members } = useMemberships(slug || '-');
   const lgUp = useMediaQuery((theme: Theme) => theme.breakpoints.up('lg'));
 
   const [tab, setTab] = useState<'all' | 'users'>('all');
@@ -60,18 +62,33 @@ const Fines = () => {
 
   return (
     <Stack direction={{ xs: 'column', lg: 'row-reverse' }} gap={{ xs: 2, lg: 1 }}>
-      <Paper sx={{ width: { xs: '100%', lg: 250 }, p: 1, alignSelf: 'self-start' }}>
+      <Paper sx={{ width: { xs: '100%', lg: 270 }, p: 1, alignSelf: 'self-start' }}>
         <Typography gutterBottom variant='h3'>
           Statistikk
         </Typography>
-        <Typography variant='body2'>
+        <Typography sx={{ fontWeight: 'bold' }} variant='body1'>
+          Totalt
+        </Typography>
+        <Typography sx={{ ml: 1 }} variant='body2'>
           Ikke godkjent: <b>{statistics?.not_approved}</b>
         </Typography>
-        <Typography variant='body2'>
+        <Typography sx={{ ml: 1 }} variant='body2'>
           Godkjent, ikke betalt: <b>{statistics?.approved_and_not_payed}</b>
         </Typography>
-        <Typography variant='body2'>
+        <Typography gutterBottom sx={{ ml: 1 }} variant='body2'>
           Betalt: <b>{statistics?.payed}</b>
+        </Typography>
+        <Typography sx={{ fontWeight: 'bold' }} variant='body1'>
+          Snitt per medlem
+        </Typography>
+        <Typography sx={{ ml: 1 }} variant='body2'>
+          Ikke godkjent: <b>{((statistics?.not_approved || 0) / (members?.pages[0].count || 1)).toFixed(1)}</b>
+        </Typography>
+        <Typography sx={{ ml: 1 }} variant='body2'>
+          Godkjent, ikke betalt: <b>{((statistics?.approved_and_not_payed || 0) / (members?.pages[0].count || 1)).toFixed(1)}</b>
+        </Typography>
+        <Typography sx={{ ml: 1 }} variant='body2'>
+          Betalt: <b>{((statistics?.payed || 0) / (members?.pages[0].count || 1)).toFixed(1)}</b>
         </Typography>
       </Paper>
       <Box sx={{ width: '100%' }}>


### PR DESCRIPTION
## Description
Made the buttons in the Fine elements say what the button does. Previously the state of the fine has been displayed.

Screenshots:
![image](https://user-images.githubusercontent.com/24162884/158849616-64b90734-6ca4-4813-b619-374968b219fb.png)

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [x] The PR includes a picture showing visual changes
- [ ] Added Analytics-events if relevant
- [x] CHANGELOG.md has been updated. [Guide](https://tihlde.slab.com/posts/changelog-z8hybjom)
