### PR TITLE
feat(fines): add image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@
 ---
 
 ## Neste versjon
+
+- ✨ **Botsystem**. Legg til bilder som bevis på bøter.
+
 ## Versjon 2022.03.24
 
 - ⚡ **Spørreskjemaer**. Spørreskjemaer som kan besvares flere ganger blir nå tømt når de besvares.

--- a/src/pages/Groups/fines/AddFineDialog.tsx
+++ b/src/pages/Groups/fines/AddFineDialog.tsx
@@ -13,6 +13,7 @@ import { useAnalytics } from 'hooks/Utils';
 import Select from 'components/inputs/Select';
 import SubmitButton from 'components/inputs/SubmitButton';
 import TextField from 'components/inputs/TextField';
+import { ImageUpload } from 'components/inputs/Upload';
 import UserSearch from 'components/inputs/UserSearch';
 import Dialog from 'components/layout/Dialog';
 
@@ -111,6 +112,7 @@ const AddFineDialog = forwardRef(function AddFineDialog({ groupSlug, ...props }:
                 required
               />
               <TextField formState={formState} label='Begrunnelse' maxRows={4} minRows={2} multiline {...register('reason')} />
+              <ImageUpload formState={formState} label='Bildebevis (Valgfritt)' register={register('image')} setValue={setValue} watch={watch} />
               <SubmitButton disabled={createFine.isLoading} formState={formState} sx={{ mt: 2 }}>
                 Opprett bot
               </SubmitButton>

--- a/src/pages/Groups/fines/FineItem.tsx
+++ b/src/pages/Groups/fines/FineItem.tsx
@@ -4,7 +4,21 @@ import ApprovedIcon from '@mui/icons-material/DoneOutlineRounded';
 import EditRounded from '@mui/icons-material/EditRounded';
 import ExpandLessIcon from '@mui/icons-material/ExpandLessRounded';
 import ExpandMoreIcon from '@mui/icons-material/ExpandMoreRounded';
-import { Button, Checkbox, Chip, Collapse, Divider, ListItem, ListItemButton, ListItemProps, ListItemText, Stack, Tooltip, Typography } from '@mui/material';
+import {
+  Button,
+  Checkbox,
+  Chip,
+  Collapse,
+  Divider,
+  ListItem,
+  ListItemButton,
+  ListItemProps,
+  ListItemText,
+  Stack,
+  styled,
+  Tooltip,
+  Typography,
+} from '@mui/material';
 import { parseISO } from 'date-fns';
 import { useState } from 'react';
 import { useForm } from 'react-hook-form';
@@ -23,6 +37,8 @@ import TextField from 'components/inputs/TextField';
 import Dialog from 'components/layout/Dialog';
 import Paper from 'components/layout/Paper';
 import VerifyDialog from 'components/layout/VerifyDialog';
+
+const Img = styled('img')(({ theme }) => ({ borderRadius: theme.shape.borderRadius, maxWidth: 600, margin: 'auto' }));
 
 export type FineItemProps = {
   fine: GroupFine;
@@ -117,6 +133,7 @@ const FineItem = ({ fine, groupSlug, isAdmin, hideUserInfo, ...props }: FineItem
             <Typography variant='subtitle2'>{`Opprettet av: ${fine.created_by.first_name} ${fine.created_by.last_name}`}</Typography>
             <Typography variant='subtitle2'>{`Dato: ${formatDate(parseISO(fine.created_at), { fullDayOfWeek: true, fullMonth: true })}`}</Typography>
           </div>
+          {fine.image && <Img alt='Bildebevis' loading='lazy' src={fine.image} width='100%' />}
           {isAdmin && (
             <>
               <Stack direction={{ xs: 'column', md: 'row' }} gap={1}>

--- a/src/pages/Groups/fines/FineItem.tsx
+++ b/src/pages/Groups/fines/FineItem.tsx
@@ -5,6 +5,7 @@ import EditRounded from '@mui/icons-material/EditRounded';
 import ExpandLessIcon from '@mui/icons-material/ExpandLessRounded';
 import ExpandMoreIcon from '@mui/icons-material/ExpandMoreRounded';
 import {
+  Box,
   Button,
   Checkbox,
   Chip,
@@ -15,7 +16,6 @@ import {
   ListItemProps,
   ListItemText,
   Stack,
-  styled,
   Tooltip,
   Typography,
 } from '@mui/material';
@@ -37,8 +37,6 @@ import TextField from 'components/inputs/TextField';
 import Dialog from 'components/layout/Dialog';
 import Paper from 'components/layout/Paper';
 import VerifyDialog from 'components/layout/VerifyDialog';
-
-const Img = styled('img')(({ theme }) => ({ borderRadius: theme.shape.borderRadius, maxWidth: 600, margin: 'auto' }));
 
 export type FineItemProps = {
   fine: GroupFine;
@@ -133,7 +131,9 @@ const FineItem = ({ fine, groupSlug, isAdmin, hideUserInfo, ...props }: FineItem
             <Typography variant='subtitle2'>{`Opprettet av: ${fine.created_by.first_name} ${fine.created_by.last_name}`}</Typography>
             <Typography variant='subtitle2'>{`Dato: ${formatDate(parseISO(fine.created_at), { fullDayOfWeek: true, fullMonth: true })}`}</Typography>
           </div>
-          {fine.image && <Img alt='Bildebevis' loading='lazy' src={fine.image} width='100%' />}
+          {fine.image && (
+            <Box alt='Bildebevis' component='img' loading='lazy' src={fine.image} sx={{ borderRadius: 1, maxWidth: 600, m: 'auto', width: '100%' }} />
+          )}
           {isAdmin && (
             <>
               <Stack direction={{ xs: 'column', md: 'row' }} gap={1}>

--- a/src/types/Group.tsx
+++ b/src/types/Group.tsx
@@ -54,15 +54,16 @@ export type GroupFine = {
   payed: boolean;
   description: string;
   reason: string;
+  image: string | null;
   created_by: UserBase;
   created_at: string;
 };
 
-export type GroupFineCreate = Pick<GroupFine, 'amount' | 'description' | 'reason'> & {
+export type GroupFineCreate = Pick<GroupFine, 'amount' | 'description' | 'image' | 'reason'> & {
   user: Array<UserBase['user_id']>;
 };
 
-export type GroupFineMutate = Partial<Pick<GroupFine, 'reason' | 'amount' | 'payed' | 'approved'>>;
+export type GroupFineMutate = Partial<Pick<GroupFine, 'reason' | 'amount' | 'image' | 'payed' | 'approved'>>;
 
 export type GroupFineBatchMutate = {
   fine_ids: Array<GroupFine['id']>;


### PR DESCRIPTION
## Description

https://github.com/TIHLDE/Lepton/pull/554

closes N/A

Changes:

- Brukere kan legge til bilde som bevis på bøter

Screenshots:
<img width="1119" alt="image" src="https://user-images.githubusercontent.com/31009729/164512312-1051cfbe-0403-44dd-a05e-d07fea36c6a2.png">


## Pull request checklist

Please check if your PR fulfills the following requirements:

- [x] The PR includes a picture showing visual changes
- [ ] Added Analytics-events if relevant
- [x] CHANGELOG.md has been updated. [Guide](https://tihlde.slab.com/posts/changelog-z8hybjom)
