### PR TITLE
feat(newstudentbox): change fadderuka signup link

### DIFF
--- a/src/pages/Landing/components/NewStudentBox.tsx
+++ b/src/pages/Landing/components/NewStudentBox.tsx
@@ -75,7 +75,7 @@ const NewStudentBox = () => {
             component='a'
             endIcon={<OpenInNewIcon />}
             fullWidth
-            href='https://s.tihlde.org/fadderuka-paamelding'
+            href='https://docs.google.com/forms/d/e/1FAIpQLSfapUHizfkU3sgxVg9EqUbkjPL1ey8OUO1UBZ-Z2mZpbGPQsA/viewform?usp=sf_link'
             onClick={fadderukaSignupAnalytics}
             rel='noopener noreferrer'
             target='_blank'


### PR DESCRIPTION
## Description

Oppdaterer lenken til fadderuke signup

closes #

Changes:

Screenshots:
<img width="1010" alt="Skjermbilde 2022-07-25 kl  17 06 04" src="https://user-images.githubusercontent.com/26656069/180811026-278b02fd-73ca-41d7-8082-4863263f2105.png">


## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] The PR includes a picture showing visual changes
- [ ] Added Analytics-events if relevant
- [ ] CHANGELOG.md has been updated. [Guide](https://tihlde.slab.com/posts/changelog-z8hybjom)
