### PR TITLE
endret påmeldingsfrist tekst fra slutt til stenger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 ## Neste versjon
 
+- ⚡ **Arrangementer**. Endret påmeldingsfrist-tekst fra "Slutt:" til "Stenger:".
 - 🦟 **Galleri**. Fikset bug som hindret opplasting av bilder.
 
 ## Versjon 2022.05.12

--- a/src/pages/EventDetails/components/EventRenderer.tsx
+++ b/src/pages/EventDetails/components/EventRenderer.tsx
@@ -306,7 +306,9 @@ const EventRenderer = ({ data, preview = false }: EventRendererProps) => {
             ) : (
               <>
                 {isFuture(userStartRegistrationDate) && <DetailContent info={formatDate(startRegistrationDate)} title='Start:' />}
-                {isPast(userStartRegistrationDate) && isFuture(endRegistrationDate) && <DetailContent info={formatDate(endRegistrationDate)} title='Slutt:' />}
+                {isPast(userStartRegistrationDate) && isFuture(endRegistrationDate) && (
+                  <DetailContent info={formatDate(endRegistrationDate)} title='Stenger:' />
+                )}
               </>
             )}
           </DetailsPaper>


### PR DESCRIPTION
## Description
Under arrangement er det påmeldingsfrist. Her sto det opprinnelig "Slutt:" med dato etterfulgt. Dette har blitt endret til "Stenger:"

closes #572 

Changes:  Endret påmeldingsfrist-tekst fra slutt til stenger

Screenshots: 
![image](https://user-images.githubusercontent.com/56680774/193083203-784a65b8-4151-4476-a557-a84d9147bc82.png)


## Pull request checklist

Please check if your PR fulfills the following requirements:

- [X] The PR includes a picture showing visual changes
- [X] CHANGELOG.md has been updated. [Guide](https://tihlde.slab.com/posts/changelog-z8hybjom)
