### PR TITLE
feat(forms): improved form admin layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@
 ---
 
 ## Neste versjon
+
+- 🎨 **Skjema**. Gruppe-skjema administrering er mer oversiktlig.
+- ⚡ **Skjema**. Filtrering på besvarte spørsmål.
+
 ## Versjon 2022.10.13
 
 - ⚡ **Analyse**. Fjernet google analytics.

--- a/src/AppRoutes.tsx
+++ b/src/AppRoutes.tsx
@@ -42,6 +42,7 @@ const EventAdministration = lazy(() => import('pages/EventAdministration'));
 const EventRegistration = lazy(() => import('pages/EventRegistration'));
 const ForgotPassword = lazy(() => import('pages/ForgotPassword'));
 const Form = lazy(() => import('pages/Form'));
+const FormAdmin = lazy(() => import('pages/Form/FormAdmin'));
 const Http404 = lazy(() => import('pages/Http404'));
 const JobPostAdministration = lazy(() => import('pages/JobPostAdministration'));
 const LogIn = lazy(() => import('pages/LogIn'));
@@ -111,7 +112,10 @@ const AppRoutes = () => {
         </Route>
         <Route element={<Companies />} path={URLS.company} />
         <Route element={<Toddel />} path={URLS.toddel} />
-        <Route element={<AuthRoute element={<Form />} />} path={`${URLS.form}:id/`} />
+        <Route path={URLS.form}>
+          <Route element={<AuthRoute element={<Form />} />} path={`:id/`} />
+          <Route element={<AuthRoute apps={[PermissionApp.GROUP]} element={<FormAdmin />} />} path={`admin/:id/`} />
+        </Route>
         <Route element={<Groups />} path={`${URLS.groups.index}*`}>
           <Route element={<GroupsOverview />} index />
           <Route element={<GroupDetails />} path=':slug/*' />

--- a/src/components/forms/FormAdmin.tsx
+++ b/src/components/forms/FormAdmin.tsx
@@ -1,3 +1,6 @@
+import { Box, Tab, Tabs, Typography } from '@mui/material';
+import { useState } from 'react';
+
 import { Form } from 'types';
 
 import { useFormById } from 'hooks/Form';
@@ -6,14 +9,45 @@ import FormAnswers from 'components/forms/FormAnswers';
 import FormDetailsEditor from 'components/forms/FormDetailsEditor';
 import FormFieldsEditor from 'components/forms/FormFieldsEditor';
 import FormStatistics from 'components/forms/FormStatistics';
-import Expand from 'components/layout/Expand';
 
 export type FormAdminProps = {
   formId: Form['id'];
 };
 
+interface TabPanelProps {
+  children?: React.ReactNode;
+  dir?: string;
+  index: number;
+  value: number;
+}
+function a11yProps(index: number) {
+  return {
+    id: `full-width-tab-${index}`,
+    'aria-controls': `full-width-tabpanel-${index}`,
+  };
+}
+
+function TabPanel(props: TabPanelProps) {
+  const { children, value, index, ...other } = props;
+
+  return (
+    <div aria-labelledby={`full-width-tab-${index}`} hidden={value !== index} id={`full-width-tabpanel-${index}`} role='tabpanel' {...other}>
+      {value === index && (
+        <Box sx={{ py: 3, px: 1 }}>
+          <Typography>{children}</Typography>
+        </Box>
+      )}
+    </div>
+  );
+}
+
 const FormAdmin = ({ formId }: FormAdminProps) => {
   const { data: form } = useFormById(formId);
+  const [value, setValue] = useState(0);
+
+  const handleChange = (event: React.SyntheticEvent, newValue: number) => {
+    setValue(newValue);
+  };
 
   if (!form) {
     return null;
@@ -21,18 +55,33 @@ const FormAdmin = ({ formId }: FormAdminProps) => {
 
   return (
     <div>
-      <Expand flat header='Skjema-innstillinger' TransitionProps={{ mountOnEnter: true }}>
-        <FormDetailsEditor form={form} />
-      </Expand>
-      <Expand flat header='Rediger spørsmål' TransitionProps={{ mountOnEnter: true }}>
-        <FormFieldsEditor form={form} />
-      </Expand>
-      <Expand flat header='Sammendrag av flervalgsspørsmål' TransitionProps={{ mountOnEnter: true }}>
-        <FormStatistics formId={form.id} />
-      </Expand>
-      <Expand flat header='Alle svar' TransitionProps={{ mountOnEnter: true }}>
-        <FormAnswers formId={form.id} />
-      </Expand>
+      <Tabs
+        aria-label='full width tabs example'
+        indicatorColor='secondary'
+        onChange={handleChange}
+        scrollButtons
+        textColor='inherit'
+        value={value}
+        variant='scrollable'>
+        <Tab label='Innstillinger' {...a11yProps(0)} />
+        <Tab label='Spørsmål' {...a11yProps(1)} />
+        <Tab label='Statestikk' {...a11yProps(2)} />
+        <Tab label='Alle svar' {...a11yProps(3)} />
+      </Tabs>
+      <>
+        <TabPanel index={0} value={value}>
+          <FormDetailsEditor form={form} />
+        </TabPanel>
+        <TabPanel index={1} value={value}>
+          <FormFieldsEditor form={form} />
+        </TabPanel>
+        <TabPanel index={2} value={value}>
+          <FormStatistics formId={form.id} />
+        </TabPanel>
+        <TabPanel index={3} value={value}>
+          <FormAnswers formId={form.id} />
+        </TabPanel>
+      </>
     </div>
   );
 };

--- a/src/components/forms/FormAnswers.tsx
+++ b/src/components/forms/FormAnswers.tsx
@@ -1,5 +1,24 @@
 import DownloadIcon from '@mui/icons-material/FileDownloadRounded';
-import { Button, Table, TableBody, TableCell, TableContainer, TableFooter, TableHead, TablePagination, TableRow, Typography } from '@mui/material';
+import {
+  Box,
+  Button,
+  Chip,
+  FormControl,
+  InputLabel,
+  MenuItem,
+  OutlinedInput,
+  Select,
+  SelectChangeEvent,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableFooter,
+  TableHead,
+  TablePagination,
+  TableRow,
+  Typography,
+} from '@mui/material';
 import { ACCESS_TOKEN, TIHLDE_API_URL, TOKEN_HEADER_NAME } from 'constant';
 import { useState } from 'react';
 import { urlEncode } from 'utils';
@@ -24,6 +43,15 @@ const FormAnswers = ({ formId }: FormAnswersProps) => {
   const [selectedPage, setSelectedPage] = useState(0);
   const { data: form, isLoading: isFormLoading } = useFormById(formId || '-');
   const { data, isLoading, error } = useFormSubmissions(formId || '-', selectedPage + 1);
+
+  const [selectedFields, setSelectedFields] = useState<string[]>([]);
+
+  const handleSelectFields = (event: SelectChangeEvent<typeof selectedFields>) => {
+    const {
+      target: { value },
+    } = event;
+    setSelectedFields(typeof value === 'string' ? value.split(',') : value);
+  };
 
   if (isLoading || isFormLoading) {
     return <Typography>Laster statistikken...</Typography>;
@@ -81,17 +109,36 @@ const FormAnswers = ({ formId }: FormAnswersProps) => {
 
   return (
     <>
-      <Button endIcon={<DownloadIcon />} onClick={downloadCSV} size='small' sx={{ width: 'fit-content', height: 35, mb: 2, ml: 'auto' }} variant='contained'>
-        Last ned som csv
-      </Button>
+      <FormControl sx={{ m: 1, width: 300 }}>
+        <InputLabel id='sporsmol-filtrering-label'>Velg spørsmål</InputLabel>
+        <Select
+          input={<OutlinedInput label='Chip' />}
+          labelId='sporsmol-filtrering-label'
+          multiple
+          onChange={handleSelectFields}
+          renderValue={(selected) => (
+            <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.5 }}>
+              {selected.map((value, index) => (
+                <Chip key={index} label={value} />
+              ))}
+            </Box>
+          )}
+          value={selectedFields}>
+          {form.fields.map((field) => (
+            <MenuItem key={field.id} value={field.title}>
+              {field.title}
+            </MenuItem>
+          ))}
+        </Select>
+      </FormControl>
       <TableContainer component={Paper} noPadding>
         <Table aria-label={`Svar for ${form.title}`} size='small' sx={{ minWidth: 250 }}>
           <TableHead>
             <TableRow>
               <TableCell sx={{ fontWeight: 'bold', whiteSpace: 'nowrap' }}>Navn</TableCell>
-              {form.fields.map((field) => (
-                <TableCell align='right' key={field.id} sx={{ fontWeight: 'bold', whiteSpace: 'nowrap' }}>
-                  {`${field.title}${field.required ? ' *' : ''}`}
+              {selectedFields.map((field, index) => (
+                <TableCell align='right' key={index} sx={{ fontWeight: 'bold', whiteSpace: 'nowrap' }}>
+                  {field}
                 </TableCell>
               ))}
             </TableRow>
@@ -102,11 +149,13 @@ const FormAnswers = ({ formId }: FormAnswersProps) => {
                 <TableCell>
                   {submission.user.first_name} {submission.user.last_name}
                 </TableCell>
-                {form.fields.map((field) => (
-                  <TableCell align='right' key={field.id}>
-                    {getTableCellText(field, submission)}
-                  </TableCell>
-                ))}
+                {form.fields
+                  .filter((field) => selectedFields.includes(field.title))
+                  .map((field) => (
+                    <TableCell align='right' key={field.id}>
+                      {getTableCellText(field, submission)}
+                    </TableCell>
+                  ))}
               </TableRow>
             ))}
           </TableBody>
@@ -124,6 +173,9 @@ const FormAnswers = ({ formId }: FormAnswersProps) => {
           </TableFooter>
         </Table>
       </TableContainer>
+      <Button endIcon={<DownloadIcon />} onClick={downloadCSV} size='small' sx={{ width: 'fit-content', height: 35, mt: 2, ml: 'auto' }} variant='contained'>
+        Last ned som csv
+      </Button>
     </>
   );
 };

--- a/src/components/forms/FormDetailsEditor.tsx
+++ b/src/components/forms/FormDetailsEditor.tsx
@@ -1,6 +1,7 @@
 import { TextField as MuiTextField, Stack } from '@mui/material';
 import { useState } from 'react';
 import { SubmitHandler, useForm } from 'react-hook-form';
+import { useNavigate } from 'react-router-dom';
 import { removeIdsFromFields } from 'utils';
 
 import { EventForm, Form, FormCreate, GroupForm, GroupFormUpdate, TemplateForm } from 'types';
@@ -21,13 +22,22 @@ export type FormDetailsEditorProps = {
 
 const DeleteFormButton = ({ form }: FormDetailsEditorProps) => {
   const deleteForm = useDeleteForm(form.id);
+  const navigate = useNavigate();
+  const showSnackbar = useSnackbar();
+
+  const deleteFormHandler = () =>
+    deleteForm.mutate(undefined, {
+      onSuccess: (data) => {
+        showSnackbar(data.detail, 'success');
+        navigate(-1);
+      },
+      onError: (e) => {
+        showSnackbar(e.detail, 'error');
+      },
+    });
 
   return (
-    <VerifyDialog
-      color='error'
-      contentText='Sletting av skjema kan ikke reverseres.'
-      disabled={deleteForm.isLoading}
-      onConfirm={() => deleteForm.mutate(undefined)}>
+    <VerifyDialog color='error' contentText='Sletting av skjema kan ikke reverseres.' disabled={deleteForm.isLoading} onConfirm={deleteFormHandler}>
       Slett spørreskjema
     </VerifyDialog>
   );
@@ -123,10 +133,12 @@ const GroupFormDetailsEditor = ({ form }: GroupFormDetailsEditorProps) => {
           name='only_for_group_members'
           type='checkbox'
         />
-        <SubmitButton disabled={updateForm.isLoading} formState={formState} sx={{ mb: 1 }}>
-          Lagre
-        </SubmitButton>
-        <DeleteFormButton form={form} />
+        <Stack direction={{ xs: 'column', sm: 'row' }} gap={2} sx={{ mb: 1, mt: 3 }}>
+          <SubmitButton disabled={updateForm.isLoading} formState={formState}>
+            Lagre
+          </SubmitButton>
+          <DeleteFormButton form={form} />
+        </Stack>
       </Stack>
     </>
   );
@@ -159,25 +171,27 @@ const EventFormDetailsEditor = ({ form }: EventFormDetailsEditorProps) => {
     });
   };
   return (
-    <Stack gap={1}>
-      <VerifyDialog
-        contentText='Når du lager en mal så kan du enkelt bruke feltene i dette skjemaet i andre skjemaer senere. Gi malen en passende tittel.'
-        dialogChildren={
-          <MuiTextField
-            disabled={false}
-            fullWidth
-            label='Tittel'
-            margin='normal'
-            onChange={(e) => setFormtemplateName(e.target.value)}
-            value={formtemplateName}
-          />
-        }
-        onConfirm={saveAsTemplate}
-        title='Lagre som mal'>
-        Lagre som mal
-      </VerifyDialog>
-      <DeleteFormButton form={form} />
-    </Stack>
+    <>
+      <Stack direction={{ xs: 'column', sm: 'row' }} gap={1}>
+        <VerifyDialog
+          contentText='Når du lager en mal så kan du enkelt bruke feltene i dette skjemaet i andre skjemaer senere. Gi malen en passende tittel.'
+          dialogChildren={
+            <MuiTextField
+              disabled={false}
+              fullWidth
+              label='Tittel'
+              margin='normal'
+              onChange={(e) => setFormtemplateName(e.target.value)}
+              value={formtemplateName}
+            />
+          }
+          onConfirm={saveAsTemplate}
+          title='Lagre som mal'>
+          Lagre som mal
+        </VerifyDialog>
+        <DeleteFormButton form={form} />
+      </Stack>
+    </>
   );
 };
 

--- a/src/components/forms/FormFieldsEditor.tsx
+++ b/src/components/forms/FormFieldsEditor.tsx
@@ -135,7 +135,7 @@ const FormFieldsEditor = ({ form, onSave, canEditTitle }: FormFieldsEditorProps)
       <Popper anchorEl={buttonAnchorRef.current} open={addButtonOpen} role={undefined} transition>
         {({ TransitionProps }) => (
           <Grow {...TransitionProps}>
-            <Paper>
+            <Paper sx={{ boxShadow: '0px 24px 48px 0 rgba(0,0,0,0.16)' }} variant='outlined'>
               <ClickAwayListener onClickAway={() => setAddButtonOpen(false)}>
                 <MenuList id='menu-list-grow'>
                   <MenuItem onClick={() => addField(FormFieldType.TEXT_ANSWER)}>Tekstspørsmål</MenuItem>

--- a/src/pages/Form/FormAdmin.tsx
+++ b/src/pages/Form/FormAdmin.tsx
@@ -1,0 +1,60 @@
+import { Stack, Typography } from '@mui/material';
+import { useMemo } from 'react';
+import { useParams } from 'react-router-dom';
+
+import { EventFormType, FormResourceType } from 'types/Enums';
+
+import { useFormById } from 'hooks/Form';
+
+import Http404 from 'pages/Http404';
+
+import FormAdminComponent from 'components/forms/FormAdmin';
+import Paper from 'components/layout/Paper';
+import { PrimaryTopBox } from 'components/layout/TopBox';
+import Page from 'components/navigation/Page';
+
+const FormPage = () => {
+  const { id } = useParams<'id'>();
+  const { data: form, isError } = useFormById(id || '-');
+
+  const title = useMemo(
+    () => (form ? (form.resource_type === FormResourceType.EVENT_FORM && form.type === EventFormType.EVALUATION ? 'Evaluering' : form.title) : ''),
+    [form],
+  );
+
+  if (isError) {
+    return <Http404 />;
+  }
+
+  return (
+    <Page banner={<PrimaryTopBox />} options={{ title: `${form?.title || 'Laster spørreskjema...'} - Spørreskjema` }}>
+      <Paper
+        sx={{
+          maxWidth: (theme) => theme.breakpoints.values.md,
+          margin: 'auto',
+          position: 'relative',
+          left: 0,
+          right: 0,
+          top: -60,
+        }}>
+        <Stack direction='column' gap={2}>
+          <Typography textAlign='center' variant='h2'>
+            Administrer skjema
+          </Typography>
+          <Typography fontWeight={600} textAlign='center'>
+            {title}
+          </Typography>
+          {form && id ? (
+            <FormAdminComponent formId={id} />
+          ) : (
+            <Typography align='center' variant='h2'>
+              Laster spørreskjema...
+            </Typography>
+          )}
+        </Stack>
+      </Paper>
+    </Page>
+  );
+};
+
+export default FormPage;

--- a/src/pages/Groups/forms/AddGroupFormDialog.tsx
+++ b/src/pages/Groups/forms/AddGroupFormDialog.tsx
@@ -2,6 +2,8 @@ import AddIcon from '@mui/icons-material/AddRounded';
 import { Button, ButtonProps } from '@mui/material';
 import { useState } from 'react';
 import { useForm } from 'react-hook-form';
+import { useNavigate } from 'react-router-dom';
+import URLS from 'URLS';
 
 import { Group, GroupFormCreate } from 'types';
 import { FormResourceType } from 'types/Enums';
@@ -21,7 +23,9 @@ const AddGroupFormDialog = ({ groupSlug, ...props }: AddGroupFormDialogProps) =>
   const [dialogOpen, setDialogOpen] = useState(false);
   const createGroupForm = useCreateForm();
   const showSnackbar = useSnackbar();
-  const { register, formState, handleSubmit, reset } = useForm<Pick<GroupFormCreate, 'title'>>();
+  const navigate = useNavigate();
+
+  const { register, formState, handleSubmit } = useForm<Pick<GroupFormCreate, 'title'>>();
 
   const submit = (data: Pick<GroupFormCreate, 'title'>) => {
     const newForm: GroupFormCreate = {
@@ -31,10 +35,9 @@ const AddGroupFormDialog = ({ groupSlug, ...props }: AddGroupFormDialogProps) =>
       fields: [],
     };
     createGroupForm.mutate(newForm, {
-      onSuccess: () => {
-        showSnackbar('Lovparagrafen ble opprettet', 'success');
-        setDialogOpen(false);
-        reset();
+      onSuccess: (form) => {
+        showSnackbar(`Skjemaet ble opprettet`, 'success');
+        navigate(`${URLS.form}admin/${form.id}`);
       },
       onError: (e) => showSnackbar(e.detail, 'error'),
     });

--- a/src/pages/Groups/forms/index.tsx
+++ b/src/pages/Groups/forms/index.tsx
@@ -5,7 +5,8 @@ import ExpandMoreIcon from '@mui/icons-material/ExpandMoreRounded';
 import OnlyMembersIcon from '@mui/icons-material/GroupsRounded';
 import OpenIcon from '@mui/icons-material/LockOpenRounded';
 import ViewIcon from '@mui/icons-material/PreviewRounded';
-import { Button, Collapse, Divider, List, ListItem, ListItemButton, ListItemIcon, ListItemText, Stack, Tooltip, Typography } from '@mui/material';
+import SettingsIcon from '@mui/icons-material/SettingsRounded';
+import { Alert, Button, Collapse, Divider, List, ListItem, ListItemButton, ListItemIcon, ListItemText, Stack, Tooltip } from '@mui/material';
 import { useState } from 'react';
 import { Link, useParams } from 'react-router-dom';
 import URLS from 'URLS';
@@ -16,7 +17,6 @@ import { useGroup, useGroupForms } from 'hooks/Group';
 
 import AddGroupFormDialog from 'pages/Groups/forms/AddGroupFormDialog';
 
-import FormAdmin from 'components/forms/FormAdmin';
 import Paper from 'components/layout/Paper';
 import NotFoundIndicator from 'components/miscellaneous/NotFoundIndicator';
 import ShareButton from 'components/miscellaneous/ShareButton';
@@ -49,11 +49,12 @@ const GroupFormAdminListItem = ({ form }: { form: GroupForm }) => {
       </ListItem>
       <Collapse in={expanded} mountOnEnter unmountOnExit>
         <Divider />
-        <Stack gap={1} sx={{ p: 1 }}>
-          {!form.is_open_for_submissions && (
-            <Typography variant='body2'>{`Du må åpne spørreskjemaet for innsending i "Skjema-innstillinger" for å kunne svare på og dele skjemaet`}</Typography>
-          )}
+        <Stack gap={2} sx={{ p: 1 }}>
+          {!form.is_open_for_submissions && <Alert severity='info'>Du må åpne spørreskjemaet for innsending for å kunne svare på og dele skjemaet.</Alert>}
           <Stack direction={{ xs: 'column', md: 'row' }} gap={1}>
+            <Button component={Link} endIcon={<SettingsIcon />} fullWidth to={`${URLS.form}admin/${form.id}/`} variant='outlined'>
+              Administrer
+            </Button>
             <Button
               component={Link}
               disabled={!form.is_open_for_submissions}
@@ -65,7 +66,6 @@ const GroupFormAdminListItem = ({ form }: { form: GroupForm }) => {
             </Button>
             <ShareButton disabled={!form.is_open_for_submissions} fullWidth shareId={form.id} shareType='form' title={form.title} />
           </Stack>
-          <FormAdmin formId={form.id} />
         </Stack>
       </Collapse>
     </Paper>


### PR DESCRIPTION
## Description
* Oppdaterer stylingen til skjema administrering. 

* Gruppe-skjema administrering får sin egen side. Denne siden kan generaliseres til alle skjema, men tenker det ikke er nødvendig nå.
* Muligheten til å filtrere på hvilke spørsmål man ønsker å se i (alle svar) siden

closes #676

Changes:

Screenshots:
<img width="1440" alt="Skjermbilde 2022-10-14 kl  11 35 13" src="https://user-images.githubusercontent.com/26656069/195815092-d890adc9-b6ab-4511-9bee-10b470eaf9c7.png">
<img width="1440" alt="Skjermbilde 2022-10-14 kl  11 35 51" src="https://user-images.githubusercontent.com/26656069/195815129-c682bb14-376a-4b16-b9a8-8741b7512e08.png">
<img width="1440" alt="Skjermbilde 2022-10-14 kl  11 36 03" src="https://user-images.githubusercontent.com/26656069/195815482-ed4b12a5-d7ba-4c16-b082-6b71748ae6f5.png">

<img width="1440" alt="Skjermbilde 2022-10-14 kl  11 37 03" src="https://user-images.githubusercontent.com/26656069/195815211-ea95ee4c-7305-4e25-9adf-98011520a36a.png">

<img width="1437" alt="Skjermbilde 2022-10-14 kl  11 36 21" src="https://user-images.githubusercontent.com/26656069/195815191-3803fcd3-3d36-442f-b856-a6ec69e4377b.png">


## Pull request checklist

Please check if your PR fulfills the following requirements:

- [x] The PR includes a picture showing visual changes
- [ ] Added Analytics-events if relevant
- [x] CHANGELOG.md has been updated. [Guide](https://tihlde.slab.com/posts/changelog-z8hybjom)
