### PR TITLE
fix(bug): fixed calendar size for mobile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 - 🦟 **Galleri**. Fikset bug som skapte duplisering av gallerier ved endring.
 - 🦟 **Galleri**. Fikset bug som hindret opplasting av bilder.
 - 🎨 **Arrangementer**. Fjernet boks som sa at arrangementet ikke ga prikker.
+- 🦟 **Kalender**. Fikset bug som gjorde arrangementene for store i kalenderen.
 
 ## Versjon 2022.05.12
 

--- a/src/pages/Landing/components/EventsCalendarView.tsx
+++ b/src/pages/Landing/components/EventsCalendarView.tsx
@@ -43,7 +43,7 @@ const Appointment = ({ children, data }: AppointmentProps) => {
   const getColor = (event: EventList) => theme.palette.colors[event.organizer?.slug.toLowerCase() === Groups.NOK.toLowerCase() ? 'nok_event' : 'other_event'];
   return (
     <>
-      <Button onClick={handleClick} sx={{ width: '100%', height: '100%', textAlign: 'left', textTransform: 'none' }}>
+      <Button onClick={handleClick} sx={{ minWidth: '40px', width: '100%', height: '100%', textAlign: 'left', textTransform: 'none' }}>
         <Appointments.Appointment data={data} draggable={false} resources={[]} style={{ backgroundColor: getColor(data as unknown as EventList) }}>
           {children}
         </Appointments.Appointment>


### PR DESCRIPTION
## Description
Fixed the size of events in the calendar for mobile

closes #697 

Changes:

Screenshots:
![image](https://user-images.githubusercontent.com/70275130/201144772-c67ae06c-46a2-4a20-89b6-948d0d22aec3.png)


## Pull request checklist

Please check if your PR fulfills the following requirements:

- [x] The PR includes a picture showing visual changes
- [ ] Added Analytics-events if relevant
- [x] CHANGELOG.md has been updated. [Guide](https://tihlde.slab.com/posts/changelog-z8hybjom)
