### PR TITLE
feat(JobPostRendering):move-logo-up

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 
 - 🎨 **Skjema**. Gruppe-skjema administrering er mer oversiktlig.
 - ⚡ **Skjema**. Filtrering på besvarte spørsmål.
+- 🎨 **Designendringer**. Flytter bildet øverst på stillingsannonser.
 
 ## Versjon 2022.10.13
 

--- a/src/pages/JobPostDetails/components/JobPostRenderer.tsx
+++ b/src/pages/JobPostDetails/components/JobPostRenderer.tsx
@@ -54,20 +54,20 @@ const JobPostRenderer = ({ data, preview = false }: JobPostRendererProps) => {
 
   return (
     <div className={classes.grid}>
-      <Paper>
-        <Typography gutterBottom variant='caption'>
-          Publisert: {publishedAt}
-        </Typography>
-        <Typography className={classes.title} gutterBottom variant='h1'>
-          {data.title}
-        </Typography>
-        <MarkdownRenderer value={data.ingress || ''} />
-        <MarkdownRenderer value={data.body} />
-      </Paper>
+      <div className={classes.infoBox}>
+        <AspectRatioImg alt={data.image_alt || data.title} borderRadius src={data.image} />
+        <Paper>
+          <Typography gutterBottom variant='caption'>
+            Publisert: {publishedAt}
+          </Typography>
+          <Typography className={classes.title} gutterBottom variant='h1'>
+            {data.title}
+          </Typography>
+          <MarkdownRenderer value={data.ingress || ''} />
+          <MarkdownRenderer value={data.body} />
+        </Paper>
+      </div>
       <div>
-        <div className={classes.infoBox}>
-          <AspectRatioImg alt={data.image_alt || data.title} borderRadius src={data.image} />
-        </div>
         <Paper className={classes.infoBox}>
           <DetailContent info={data.company} title='Bedrift: ' />
           <DetailContent info={data.is_continuously_hiring ? 'Fortløpende opptak' : deadline} title='Søknadsfrist: ' />


### PR DESCRIPTION
## Description

closes #711 

Changes: Logoen til bedrifter som har utlyst stillinger ble dyttet nederst på siden. Nå er denne flyttet øverst.

Screenshots:
![image](https://user-images.githubusercontent.com/56680774/202507344-4aa8fd13-16b7-49db-b46b-830d9fcafdf4.png)


## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ x] The PR includes a picture showing visual changes
- [ ] Added Analytics-events if relevant
- [x ] CHANGELOG.md has been updated. [Guide](https://tihlde.slab.com/posts/changelog-z8hybjom)
