### PR TITLE
Feat/new event button for arrangements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 ## Neste versjon
 - ✨ **Badge**. Bades kan erverves gjennom en lenke.
 - 🦟 **Arrangementer**. En kan nå kun trykke på påmelding knappen en gang, dette eliminerer problemet med mange mails/meldinger.
+- ✨ **Arrangementer**. Opprettelse av arrangement på "gruppe"-sider.
 
 ## Versjon 2022.11.17
 

--- a/src/pages/Groups/events/index.tsx
+++ b/src/pages/Groups/events/index.tsx
@@ -1,6 +1,8 @@
+import AddIcon from '@mui/icons-material/EditRounded';
 import { Stack } from '@mui/material';
+import { Button } from '@mui/material';
 import { useMemo } from 'react';
-import { useParams } from 'react-router-dom';
+import { Link, useParams } from 'react-router-dom';
 
 import { useEvents } from 'hooks/Event';
 import { useGroup } from 'hooks/Group';
@@ -18,6 +20,9 @@ const GroupEvents = () => {
 
   return (
     <Stack>
+      <Button component={Link} to='/admin/arrangementer' fullWidth startIcon={<AddIcon />} sx={{ mt: 1 }} variant='outlined'>
+        Nytt arrangement
+      </Button>
       {isLoading && <EventListItemLoading />}
       {!isLoading && !events.length && <NotFoundIndicator header={`${group?.name} har ingen kommende arrangementer`} />}
       {error && <Paper>{error.detail}</Paper>}


### PR DESCRIPTION
## Description

closes #658 

Changes: ny knapp for å lett opprette nye arrangementer.

Screenshots:
<br>
![image](https://user-images.githubusercontent.com/123838995/218494674-87585de1-a2f4-4d15-b177-eb0c9dbed627.png)


## Pull request checklist

Please check if your PR fulfills the following requirements:

- [x] The PR includes a picture showing visual changes
- [ ] Added Analytics-events if relevant
- [x] CHANGELOG.md has been updated. [Guide](https://tihlde.slab.com/posts/changelog-z8hybjom)
