### PR TITLE
it is now not possible to turn of paid event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@
 ## Neste versjon
 - ✨ **Bannere**. Tidsbegrensede bannere kan nå opprettes.
 
+## versjon 2023.10.13
+
+- ⚡**Oppdatering betalt arrangement**. Kan ikke skru av betalt arrangement.
+
 ## versjon 2023.24.09
 
 - 🎨 **Fult navn**. Kontaktperson på arrangementer vil nå bli vist med fult navn.

--- a/src/pages/EventAdministration/components/EventEditor.tsx
+++ b/src/pages/EventAdministration/components/EventEditor.tsx
@@ -467,6 +467,7 @@ const EventEditor = ({ eventId, goToEvent }: EventEditorProps) => {
           </Row>
           <Bool
             control={control}
+            disabled={Boolean(data?.is_paid_event)}
             formState={formState}
             label={
               <>


### PR DESCRIPTION
## Description

Disable the option to turn off paid events

closes #

Changes:

Screenshots:

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] The PR includes a picture showing visual changes
- [ ] Added Analytics-events if relevant
- [x] CHANGELOG.md has been updated. [Guide](https://tihlde.slab.com/posts/changelog-z8hybjom)
