### PR TITLE
waiting-list will now only be sorted if there is a priority pool

### DIFF
--- a/src/pages/EventAdministration/components/EventParticipants.tsx
+++ b/src/pages/EventAdministration/components/EventParticipants.tsx
@@ -21,6 +21,7 @@ import EventUserRegistrator from './EventUserRegistrator';
 type RegistrationsProps = {
   onWait?: boolean;
   eventId: Event['id'];
+  needsSorting?: boolean;
 };
 
 type RegistrationsCopyDetails = {
@@ -28,7 +29,7 @@ type RegistrationsCopyDetails = {
   emails: boolean;
 };
 
-const Registrations = ({ onWait = false, eventId }: RegistrationsProps) => {
+const Registrations = ({ onWait = false, eventId, needsSorting = false }: RegistrationsProps) => {
   const [showOnlyNotAttended, setShowOnlyNotAttended] = useState(false);
   const { data, hasNextPage, isFetching, isLoading, fetchNextPage } = useEventRegistrations(eventId, { is_on_wait: onWait });
   const { register, handleSubmit } = useForm({
@@ -46,11 +47,15 @@ const Registrations = ({ onWait = false, eventId }: RegistrationsProps) => {
     [data, showOnlyNotAttended],
   );
 
-  const sortedRegistrations = registrations.sort((a, b) => {
-    const waitA = a.wait_queue_number ?? Number.MAX_SAFE_INTEGER;
-    const waitB = b.wait_queue_number ?? Number.MAX_SAFE_INTEGER;
-    return waitA - waitB;
-  });
+  let sortedRegistrations = registrations;
+
+  if (needsSorting) {
+    sortedRegistrations = registrations.sort((a, b) => {
+      const waitA = a.wait_queue_number ?? Number.MAX_SAFE_INTEGER;
+      const waitB = b.wait_queue_number ?? Number.MAX_SAFE_INTEGER;
+      return waitA - waitB;
+    });
+  }
 
   const showSnackbar = useSnackbar();
 
@@ -145,6 +150,8 @@ const EventParticipants = ({ eventId }: EventParticipantsProps) => {
     return <LinearProgress />;
   }
 
+  const needsSorting = data && data.priority_pools && data.priority_pools.length > 0;
+
   return (
     <>
       <Typography variant='h2'>{data?.title || 'Laster...'}</Typography>
@@ -160,7 +167,7 @@ const EventParticipants = ({ eventId }: EventParticipantsProps) => {
           <EventUserRegistrator eventId={eventId} />
         </Stack>
         <Registrations eventId={eventId} />
-        <Registrations eventId={eventId} onWait />
+        <Registrations eventId={eventId} needsSorting={needsSorting} onWait />
       </div>
     </>
   );


### PR DESCRIPTION
## Description

closes #

Changes:

waiting list will now only do sorting when the event has priority pool. this was needed because the sorting takes some time (issue for the future to make this quicker), and on events that are without priority pools, the ordering is not needed.

Screenshots:

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] The PR includes a picture showing visual changes
- [ ] Added Analytics-events if relevant
- [ ] CHANGELOG.md has been updated. [Guide](https://tihlde.slab.com/posts/changelog-z8hybjom)
