### PR TITLE
Remove MUI from signin pages

### DIFF
--- a/src/components/navigation/Topbar.tsx
+++ b/src/components/navigation/Topbar.tsx
@@ -72,12 +72,16 @@ const Topbar = ({ items }: TopbarProps) => {
 
   if (!isMediumScreen) {
     return (
-      <div className='absolute top-0 left-0 right-0 z-30 p-2 flex justify-between items-center'>
+      <header
+        className={cn(
+          'fixed z-30 w-full top-0 transition-all duration-150 p-2 flex items-center justify-between',
+          !isOnTop && 'border-b border-border/40 bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60',
+        )}>
         <Link aria-label='Til forsiden' to={URLS.landing}>
           <TihldeLogo className='h-[24px] w-auto ml-0' size='large' />{' '}
         </Link>
         <ProfileTopbarButton />
-      </div>
+      </header>
     );
   }
 

--- a/src/pages/ForgotPassword/index.tsx
+++ b/src/pages/ForgotPassword/index.tsx
@@ -1,101 +1,90 @@
-import Button from '@mui/material/Button';
-import LinearProgress from '@mui/material/LinearProgress';
-import Typography from '@mui/material/Typography';
-import { EMAIL_REGEX } from 'constant';
-import { makeStyles } from 'makeStyles';
+import { zodResolver } from '@hookform/resolvers/zod';
 import { useForm } from 'react-hook-form';
 import { Link } from 'react-router-dom';
 import URLS from 'URLS';
+import { z } from 'zod';
 
 import { useSnackbar } from 'hooks/Snackbar';
 import { useForgotPassword } from 'hooks/User';
 import { useAnalytics } from 'hooks/Utils';
 
-import SubmitButton from 'components/inputs/SubmitButton';
-import TextField from 'components/inputs/TextField';
-import Paper from 'components/layout/Paper';
-import { SecondaryTopBox } from 'components/layout/TopBox';
-import TihldeLogo from 'components/miscellaneous/TihldeLogo';
-import Page from 'components/navigation/Page';
+import { Button, buttonVariants } from 'components/ui/button';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from 'components/ui/card';
+import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from 'components/ui/form';
+import { Input } from 'components/ui/input';
 
-const useStyles = makeStyles()((theme) => ({
-  paper: {
-    maxWidth: theme.breakpoints.values.sm,
-    margin: 'auto',
-    position: 'relative',
-    left: 0,
-    right: 0,
-    top: -60,
-  },
-  logo: {
-    height: 30,
-    width: 'auto',
-    marginBottom: theme.spacing(1),
-  },
-  progress: {
-    position: 'absolute',
-    top: 0,
-    left: 0,
-    right: 0,
-  },
-  button: {
-    marginTop: theme.spacing(2),
-  },
-}));
-
-type FormData = {
-  email: string;
-};
+const formSchema = z.object({
+  email: z.string().email('Ugyldig e-post').min(1, { message: 'Feltet er påkrevd' }),
+});
 
 const ForgotPassword = () => {
-  const { classes } = useStyles();
   const { event } = useAnalytics();
   const forgotPassword = useForgotPassword();
   const showSnackbar = useSnackbar();
-  const { register, formState, handleSubmit, setError } = useForm<FormData>();
 
-  const onSubmit = async (data: FormData) => {
-    forgotPassword.mutate(data.email, {
+  const form = useForm<z.infer<typeof formSchema>>({
+    resolver: zodResolver(formSchema),
+    defaultValues: {
+      email: '',
+    },
+  });
+
+  const onSubmit = async (values: z.infer<typeof formSchema>) => {
+    forgotPassword.mutate(values.email, {
       onSuccess: (data) => {
         showSnackbar(data.detail, 'success');
         event('forgot-password', 'auth', 'Forgot password');
       },
       onError: (e) => {
-        setError('email', { message: e.detail });
+        form.setError('email', { message: e.detail });
       },
     });
   };
 
   return (
-    <Page banner={<SecondaryTopBox />} options={{ title: 'Glemt passord' }}>
-      <Paper className={classes.paper}>
-        {forgotPassword.isLoading && <LinearProgress className={classes.progress} />}
-        <TihldeLogo className={classes.logo} size='large' />
-        <Typography variant='h3'>Glemt passord</Typography>
-        <form onSubmit={handleSubmit(onSubmit)}>
-          <TextField
-            disabled={forgotPassword.isLoading}
-            formState={formState}
-            label='Epost'
-            {...register('email', {
-              required: 'Feltet er påkrevd',
-              pattern: {
-                value: EMAIL_REGEX,
-                message: 'Ugyldig e-post',
-              },
-            })}
-            required
-            type='email'
-          />
-          <SubmitButton className={classes.button} disabled={forgotPassword.isLoading} formState={formState}>
-            Få nytt passord
-          </SubmitButton>
-          <Button className={classes.button} component={Link} disabled={forgotPassword.isLoading} fullWidth to={URLS.login}>
-            Logg inn
-          </Button>
-        </form>
-      </Paper>
-    </Page>
+    <div className='px-2 md:px-8 mt-32 flex items-center justify-center'>
+      <Card className='max-w-lg w-full'>
+        <CardHeader>
+          <CardTitle>Glemt passord?</CardTitle>
+          <CardDescription>Skriv inn din e-postadresse for å motta en e-post med et nytt passord.</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <Form {...form}>
+            <form className='space-y-6' onSubmit={form.handleSubmit(onSubmit)}>
+              <FormField
+                control={form.control}
+                name='email'
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>
+                      Epost <span className='text-red-300'>*</span>
+                    </FormLabel>
+                    <FormControl>
+                      <Input placeholder='Skriv her...' type='email' {...field} />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+
+              <Button className='w-full' disabled={forgotPassword.isLoading} size='lg' type='submit'>
+                {forgotPassword.isLoading ? 'Henter nytt passord...' : 'Få nytt passord'}
+              </Button>
+            </form>
+          </Form>
+
+          <div className='flex items-center justify-center space-x-12 mt-6'>
+            <Link className={buttonVariants({ variant: 'link' })} to={URLS.login}>
+              Logg inn
+            </Link>
+
+            <Link className={buttonVariants({ variant: 'link' })} to={URLS.signup}>
+              Opprett bruker
+            </Link>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
   );
 };
 

--- a/src/pages/LogIn/index.tsx
+++ b/src/pages/LogIn/index.tsx
@@ -1,70 +1,41 @@
-import Button from '@mui/material/Button';
-import LinearProgress from '@mui/material/LinearProgress';
-import Typography from '@mui/material/Typography';
-import { makeStyles } from 'makeStyles';
+import { zodResolver } from '@hookform/resolvers/zod';
 import { useForm } from 'react-hook-form';
 import { Link, useNavigate } from 'react-router-dom';
 import URLS from 'URLS';
+import { z } from 'zod';
 
 import { useRedirectUrl, useSetRedirectUrl } from 'hooks/Misc';
 import { useLogin } from 'hooks/User';
 import { useAnalytics } from 'hooks/Utils';
 
-import SubmitButton from 'components/inputs/SubmitButton';
-import TextField from 'components/inputs/TextField';
-import Paper from 'components/layout/Paper';
-import { SecondaryTopBox } from 'components/layout/TopBox';
-import TihldeLogo from 'components/miscellaneous/TihldeLogo';
-import Page from 'components/navigation/Page';
+import { Button, buttonVariants } from 'components/ui/button';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from 'components/ui/card';
+import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from 'components/ui/form';
+import { Input } from 'components/ui/input';
 
-const useStyles = makeStyles()((theme) => ({
-  paper: {
-    maxWidth: theme.breakpoints.values.sm,
-    margin: 'auto',
-    position: 'relative',
-    overflow: 'hidden',
-    left: 0,
-    right: 0,
-    top: -60,
-  },
-  logo: {
-    height: 30,
-    width: 'auto',
-    marginBottom: theme.spacing(1),
-  },
-  progress: {
-    position: 'absolute',
-    top: -1,
-    left: 0,
-    right: 0,
-  },
-  buttons: {
-    display: 'grid',
-    gridTemplateColumns: '1fr 1fr',
-    gridGap: theme.spacing(1),
-  },
-  button: {
-    marginTop: theme.spacing(2),
-  },
-}));
-
-type LoginData = {
-  username: string;
-  password: string;
-};
+const formSchema = z.object({
+  username: z.string().min(1, { message: 'Brukernavn er påkrevd' }),
+  password: z.string().min(1, { message: 'Passorde er påkrevd' }),
+});
 
 const LogIn = () => {
-  const { classes } = useStyles();
   const navigate = useNavigate();
   const { event } = useAnalytics();
   const logIn = useLogin();
   const setLogInRedirectURL = useSetRedirectUrl();
   const redirectURL = useRedirectUrl();
-  const { register, formState, handleSubmit, setError } = useForm<LoginData>();
 
-  const onLogin = async (data: LoginData) => {
+  const form = useForm<z.infer<typeof formSchema>>({
+    resolver: zodResolver(formSchema),
+    defaultValues: {
+      username: '',
+      password: '',
+    },
+  });
+
+  const onLogin = async (values: z.infer<typeof formSchema>) => {
     logIn.mutate(
-      { username: data.username, password: data.password },
+      { username: values.username, password: values.password },
       {
         onSuccess: () => {
           event('login', 'auth', `Logged in`);
@@ -72,51 +43,72 @@ const LogIn = () => {
           navigate(redirectURL || URLS.landing);
         },
         onError: (e) => {
-          setError('password', { message: e.detail || 'Noe gikk galt' });
+          form.setError('username', { message: e.detail || 'Noe gikk galt' });
         },
       },
     );
   };
 
   return (
-    <Page banner={<SecondaryTopBox />} options={{ title: 'Logg inn' }}>
-      <Paper className={classes.paper}>
-        {logIn.isLoading && <LinearProgress className={classes.progress} />}
-        <TihldeLogo className={classes.logo} size='large' />
-        <Typography variant='h3'>Logg inn</Typography>
-        <form onSubmit={handleSubmit(onLogin)}>
-          <TextField
-            disabled={logIn.isLoading}
-            formState={formState}
-            label='Brukernavn'
-            {...register('username', {
-              required: 'Feltet er påkrevd',
-              validate: (value: string) => (value.includes('@') ? 'Bruk Feide-brukernavn, ikke epost' : undefined),
-            })}
-            required
-          />
-          <TextField
-            disabled={logIn.isLoading}
-            formState={formState}
-            label='Passord'
-            {...register('password', { required: 'Feltet er påkrevd' })}
-            required
-            type='password'
-          />
-          <SubmitButton className={classes.button} disabled={logIn.isLoading} formState={formState}>
-            Logg inn
-          </SubmitButton>
-          <div className={classes.buttons}>
-            <Button className={classes.button} component={Link} disabled={logIn.isLoading} fullWidth to={URLS.forgotPassword}>
+    <div className='px-2 md:px-8 mt-32 flex items-center justify-center'>
+      <Card className='max-w-lg w-full'>
+        <CardHeader>
+          <CardTitle>Logg inn</CardTitle>
+          <CardDescription>Logg inn med ditt TIHLDE brukernavn og passord</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <Form {...form}>
+            <form className='space-y-6' onSubmit={form.handleSubmit(onLogin)}>
+              <FormField
+                control={form.control}
+                name='username'
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>
+                      Brukernavn <span className='text-red-300'>*</span>
+                    </FormLabel>
+                    <FormControl>
+                      <Input placeholder='Skriv her...' {...field} />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+
+              <FormField
+                control={form.control}
+                name='password'
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>
+                      Passord <span className='text-red-300'>*</span>
+                    </FormLabel>
+                    <FormControl>
+                      <Input placeholder='Skriv her...' type='password' {...field} />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+
+              <Button className='w-full' disabled={logIn.isLoading} size='lg' type='submit'>
+                {logIn.isLoading ? 'Logger inn...' : 'Logg inn'}
+              </Button>
+            </form>
+          </Form>
+
+          <div className='flex items-center justify-center space-x-12 mt-6'>
+            <Link className={buttonVariants({ variant: 'link' })} to={URLS.forgotPassword}>
               Glemt passord?
-            </Button>
-            <Button className={classes.button} component={Link} disabled={logIn.isLoading} fullWidth to={URLS.signup}>
+            </Link>
+
+            <Link className={buttonVariants({ variant: 'link' })} to={URLS.signup}>
               Opprett bruker
-            </Button>
+            </Link>
           </div>
-        </form>
-      </Paper>
-    </Page>
+        </CardContent>
+      </Card>
+    </div>
   );
 };
 

--- a/src/pages/SignUp/index.tsx
+++ b/src/pages/SignUp/index.tsx
@@ -1,11 +1,9 @@
-import ExpandLessIcon from '@mui/icons-material/ExpandLessRounded';
-import ExpandMoreIcon from '@mui/icons-material/ExpandMoreRounded';
-import { Button, Collapse, LinearProgress, MenuItem, Stack, Typography } from '@mui/material';
-import { EMAIL_REGEX } from 'constant';
-import { useState } from 'react';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { Info } from 'lucide-react';
 import { useForm } from 'react-hook-form';
 import { Link, useNavigate } from 'react-router-dom';
 import URLS from 'URLS';
+import { z } from 'zod';
 
 import { UserCreate } from 'types';
 
@@ -16,17 +14,31 @@ import { useSnackbar } from 'hooks/Snackbar';
 import { useCreateUser } from 'hooks/User';
 import { useAnalytics } from 'hooks/Utils';
 
-import Select from 'components/inputs/Select';
-import SubmitButton from 'components/inputs/SubmitButton';
-import TextField from 'components/inputs/TextField';
-import Paper from 'components/layout/Paper';
-import { SecondaryTopBox } from 'components/layout/TopBox';
-import TihldeLogo from 'components/miscellaneous/TihldeLogo';
-import Page from 'components/navigation/Page';
+import { Alert, AlertDescription, AlertTitle } from 'components/ui/alert';
+import { Button, buttonVariants } from 'components/ui/button';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from 'components/ui/card';
+import { Form, FormControl, FormDescription, FormField, FormItem, FormLabel, FormMessage } from 'components/ui/form';
+import { Input } from 'components/ui/input';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from 'components/ui/select';
 
-type SignUpData = UserCreate & {
-  password_verify: string;
-};
+const formSchema = z
+  .object({
+    class: z.string().min(1, { message: 'Feltet er påkrevd' }),
+    email: z.string().email('Ugyldig e-post').min(1, { message: 'Feltet er påkrevd' }),
+    first_name: z.string().min(1, { message: 'Feltet er påkrevd' }),
+    last_name: z.string().min(1, { message: 'Feltet er påkrevd' }),
+    study: z.string().min(1, { message: 'Feltet er påkrevd' }),
+    user_id: z
+      .string()
+      .min(1, { message: 'Feltet er påkrevd' })
+      .refine((value) => !value.includes('@'), { message: 'Brukernavn må være uten @stud.ntnu.no' }),
+    password: z.string().min(8, { message: 'Minimum 8 karakterer' }),
+    password_verify: z.string().min(8, { message: 'Minimum 8 karakterer' }),
+  })
+  .refine((data) => data.password === data.password_verify, {
+    message: 'Passordene må være like',
+    path: ['password_verify'],
+  });
 
 const SignUp = () => {
   const { run } = useConfetti();
@@ -36,27 +48,34 @@ const SignUp = () => {
   const navigate = useNavigate();
   const createUser = useCreateUser();
   const showSnackbar = useSnackbar();
-  const { handleSubmit, formState, control, getValues, setError, register } = useForm<SignUpData>();
   const setLogInRedirectURL = useSetRedirectUrl();
   const redirectURL = useRedirectUrl();
-  const [faqOpen, setFaqOpen] = useState(false);
 
-  const onSignUp = async (data: SignUpData) => {
-    if (data.password !== data.password_verify) {
-      setError('password', { message: 'Passordene må være like' });
-      setError('password_verify', { message: 'Passordene må være like' });
-      return;
-    }
+  const form = useForm<z.infer<typeof formSchema>>({
+    resolver: zodResolver(formSchema),
+    defaultValues: {
+      class: '',
+      email: '',
+      first_name: '',
+      last_name: '',
+      study: '',
+      user_id: '',
+      password: '',
+      password_verify: '',
+    },
+  });
 
+  const onSignUp = async (values: z.infer<typeof formSchema>) => {
     const userData: UserCreate = {
-      user_id: data.user_id.toLowerCase(),
-      first_name: data.first_name,
-      last_name: data.last_name,
-      email: data.email,
-      password: data.password,
-      class: data.class,
-      study: data.study,
+      user_id: values.user_id.toLowerCase(),
+      first_name: values.first_name,
+      last_name: values.last_name,
+      email: values.email,
+      password: values.password,
+      class: values.class,
+      study: values.study,
     };
+
     createUser.mutate(userData, {
       onSuccess: () => {
         run();
@@ -71,127 +90,208 @@ const SignUp = () => {
   };
 
   return (
-    <Page banner={<SecondaryTopBox />} options={{ title: 'Ny bruker' }}>
-      <Paper sx={{ maxWidth: 'md', margin: 'auto', position: 'relative', left: 0, right: 0, top: -60 }}>
-        {createUser.isLoading && <LinearProgress sx={{ position: 'absolute', top: 0, left: 0, right: 0 }} />}
-        <TihldeLogo size='large' />
-        <Typography variant='h3'>Opprett bruker</Typography>
-        <Stack component='form' onSubmit={handleSubmit(onSignUp)}>
-          <Stack direction={{ xs: 'column', sm: 'row' }} gap={1}>
-            <TextField
-              disabled={createUser.isLoading}
-              formState={formState}
-              label='Fornavn'
-              {...register('first_name', { required: 'Feltet er påkrevd' })}
-              required
-            />
-            <TextField
-              disabled={createUser.isLoading}
-              formState={formState}
-              label='Etternavn'
-              {...register('last_name', { required: 'Feltet er påkrevd' })}
-              required
-            />
-          </Stack>
-          <TextField
-            disabled={createUser.isLoading}
-            formState={formState}
-            helperText='Ditt brukernavn på NTNU'
-            label='Feide brukernavn'
-            {...register('user_id', { required: 'Feltet er påkrevd', validate: (value) => !value.includes('@') || 'Brukernavn må være uten @stud.ntnu.no' })}
-            required
-          />
-          <TextField
-            disabled={createUser.isLoading}
-            formState={formState}
-            helperText='Benytt en mail du sjekker regelmessig'
-            label='E-post'
-            {...register('email', {
-              required: 'Feltet er påkrevd',
-              pattern: {
-                value: EMAIL_REGEX,
-                message: 'Ugyldig e-post',
-              },
-            })}
-            required
-            type='email'
-          />
-          <Stack direction={{ xs: 'column', sm: 'row' }} gap={1}>
-            <Select control={control} formState={formState} label='Studie' name='study' required rules={{ required: 'Feltet er påkrevd' }}>
-              {studies?.map((study) => (
-                <MenuItem key={study.slug} value={study.slug}>
-                  {study.name}
-                </MenuItem>
-              ))}
-            </Select>
-            <Select
-              control={control}
-              formState={formState}
-              helperText='Hvilket år begynte du på studiet ditt? Om du går DigSam, trekk fra 3 år i tillegg.'
-              label='Kull'
-              name='class'
-              required
-              rules={{ required: 'Feltet er påkrevd' }}>
-              {studyyears?.map((study) => (
-                <MenuItem key={study.slug} value={study.slug}>
-                  {study.name}
-                </MenuItem>
-              ))}
-            </Select>
-          </Stack>
-          <Stack direction={{ xs: 'column', sm: 'row' }} gap={1}>
-            <TextField
-              disabled={createUser.isLoading}
-              formState={formState}
-              label='Passord'
-              {...register('password', {
-                required: 'Feltet er påkrevd',
-                minLength: {
-                  value: 8,
-                  message: 'Minimum 8 karakterer',
-                },
-              })}
-              required
-              type='password'
-            />
-            <TextField
-              disabled={createUser.isLoading}
-              formState={formState}
-              label='Gjenta passord'
-              {...register('password_verify', {
-                required: 'Feltet er påkrevd',
-                validate: {
-                  passordEqual: (value) => value === getValues().password || 'Passordene er ikke like',
-                },
-              })}
-              required
-              type='password'
-            />
-          </Stack>
-          <Typography gutterBottom my={1} textAlign={'center'} variant='body2'>
-            Etter du har opprettet bruker må vi fortsatt godkjenne deg før du kan logge inn!
-          </Typography>
-          <SubmitButton disabled={createUser.isLoading} formState={formState}>
-            Opprett bruker
-          </SubmitButton>
-          <Button component={Link} disabled={createUser.isLoading} fullWidth sx={{ my: 1 }} to={URLS.login}>
-            Logg inn
-          </Button>
-          <Button endIcon={faqOpen ? <ExpandLessIcon /> : <ExpandMoreIcon />} fullWidth onClick={() => setFaqOpen((oldState) => !oldState)} variant='outlined'>
-            Hvorfor må vi godkjenne deg?
-          </Button>
-          <Collapse in={faqOpen}>
-            <Typography m={1} variant='body2'>
-              {`For å unngå at vi får mange brukere som ikke er reelle TIHLDE-medlemmer, må vi aktivere nye brukere før de får logge inn. For å få aktivert brukeren din kan du ta kontakt med `}
-              <a href='mailto:teknologiminister@tihlde.org' rel='noopener noreferrer' target='_blank'>
-                Teknologiminister
-              </a>
-              .
-            </Typography>
-          </Collapse>
-        </Stack>
-      </Paper>
-    </Page>
+    <div className='px-2 md:px-8 mt-32 pb-20 flex items-center justify-center'>
+      <Card className='max-w-3xl w-full'>
+        <CardHeader>
+          <CardTitle>Opprett bruker</CardTitle>
+          <CardDescription>Opprett en bruker for å få tilgang til TIHLDE sine tjenester</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <Form {...form}>
+            <form className='space-y-6' onSubmit={form.handleSubmit(onSignUp)}>
+              <div className='flex space-x-4'>
+                <FormField
+                  control={form.control}
+                  name='first_name'
+                  render={({ field }) => (
+                    <FormItem className='w-full'>
+                      <FormLabel>
+                        Fornavn <span className='text-red-300'>*</span>
+                      </FormLabel>
+                      <FormControl>
+                        <Input placeholder='Skriv her...' {...field} />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+
+                <FormField
+                  control={form.control}
+                  name='last_name'
+                  render={({ field }) => (
+                    <FormItem className='w-full'>
+                      <FormLabel>
+                        Etternavn <span className='text-red-300'>*</span>
+                      </FormLabel>
+                      <FormControl>
+                        <Input placeholder='Skriv her...' {...field} />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+              </div>
+
+              <div className='flex space-x-4'>
+                <FormField
+                  control={form.control}
+                  name='user_id'
+                  render={({ field }) => (
+                    <FormItem className='w-full'>
+                      <FormLabel>
+                        Feide brukernavn <span className='text-red-300'>*</span>
+                      </FormLabel>
+                      <FormControl>
+                        <Input placeholder='Skriv her...' {...field} />
+                      </FormControl>
+                      <FormDescription className='text-xs'>Ditt brukernavn på NTNU</FormDescription>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+
+                <FormField
+                  control={form.control}
+                  name='email'
+                  render={({ field }) => (
+                    <FormItem className='w-full'>
+                      <FormLabel>
+                        Epost <span className='text-red-300'>*</span>
+                      </FormLabel>
+                      <FormControl>
+                        <Input placeholder='Skriv her...' type='email' {...field} />
+                      </FormControl>
+                      <FormDescription className='text-xs'>Benytt en epost du sjekker regelmessig</FormDescription>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+              </div>
+
+              <div className='flex space-x-4'>
+                <FormField
+                  control={form.control}
+                  name='study'
+                  render={({ field }) => (
+                    <FormItem className='w-full'>
+                      <FormLabel>
+                        Studie <span className='text-red-300'>*</span>
+                      </FormLabel>
+                      <Select defaultValue={field.value} onValueChange={(value) => field.onChange(value)}>
+                        <FormControl>
+                          <SelectTrigger>
+                            <SelectValue placeholder='Velg studie' />
+                          </SelectTrigger>
+                        </FormControl>
+                        <SelectContent>
+                          {studies?.map((study, index) => (
+                            <SelectItem key={index} value={study.slug}>
+                              {study.name}
+                            </SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+
+                <FormField
+                  control={form.control}
+                  name='class'
+                  render={({ field }) => (
+                    <FormItem className='w-full'>
+                      <FormLabel>
+                        Kull <span className='text-red-300'>*</span>
+                      </FormLabel>
+                      <Select defaultValue={field.value} onValueChange={(value) => field.onChange(value)}>
+                        <FormControl>
+                          <SelectTrigger>
+                            <SelectValue placeholder='Velg kull' />
+                          </SelectTrigger>
+                        </FormControl>
+                        <SelectContent>
+                          {studyyears?.map((year, index) => (
+                            <SelectItem key={index} value={year.slug}>
+                              {year.name}
+                            </SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
+                      <FormDescription className='text-xs'>
+                        Hvilket år begynte du på studiet ditt? Om du går DigTrans, trekk fra 3 år i tillegg.
+                      </FormDescription>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+              </div>
+
+              <div className='flex space-x-4'>
+                <FormField
+                  control={form.control}
+                  name='password'
+                  render={({ field }) => (
+                    <FormItem className='w-full'>
+                      <FormLabel>
+                        Passord <span className='text-red-300'>*</span>
+                      </FormLabel>
+                      <FormControl>
+                        <Input placeholder='Skriv her...' type='password' {...field} />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+
+                <FormField
+                  control={form.control}
+                  name='password_verify'
+                  render={({ field }) => (
+                    <FormItem className='w-full'>
+                      <FormLabel>
+                        Gjenta passord <span className='text-red-300'>*</span>
+                      </FormLabel>
+                      <FormControl>
+                        <Input placeholder='Skriv her...' type='password' {...field} />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+              </div>
+
+              <Alert variant='warning'>
+                <Info className='w-4 h-4' />
+                <AlertTitle className='pb-4'>Etter du har opprettet bruker må vi fortsatt godkjenne deg før du kan logge inn!</AlertTitle>
+                <AlertDescription>
+                  For å unngå at vi får mange brukere som ikke er reelle TIHLDE-medlemmer, må vi aktivere nye brukere før de får logge inn. For å få aktivert
+                  brukeren din kan du ta kontakt med{' '}
+                  <a className='text-blue-500 hover:underline' href='mailto:hs@tihlde.org' rel='noopener noreferrer' target='_blank'>
+                    hs@tihlde.org
+                  </a>
+                </AlertDescription>
+              </Alert>
+
+              <Button className='w-full' disabled={createUser.isLoading} size='lg' type='submit'>
+                {createUser.isLoading ? 'Oppretter bruker...' : 'Opprett bruker'}
+              </Button>
+            </form>
+          </Form>
+
+          <div className='flex items-center justify-center space-x-12 mt-6'>
+            <Link className={buttonVariants({ variant: 'link' })} to={URLS.forgotPassword}>
+              Glemt passord?
+            </Link>
+
+            <Link className={buttonVariants({ variant: 'link' })} to={URLS.login}>
+              Logg inn
+            </Link>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
   );
 };
 


### PR DESCRIPTION
## Description
This will remove MUI from signin, signup and forgot password pages, and use shadcn

closes #

Changes:

Screenshots:

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] The PR includes a picture showing visual changes
- [ ] Added Analytics-events if relevant
- [ ] CHANGELOG.md has been updated. [Guide](https://tihlde.slab.com/posts/changelog-z8hybjom)
