### PR TITLE
Added button for facebook page

### DIFF
--- a/src/pages/EventDetails/components/EventRenderer.tsx
+++ b/src/pages/EventDetails/components/EventRenderer.tsx
@@ -386,6 +386,13 @@ const EventRenderer = ({ data, preview = false }: EventRendererProps) => {
                   )}
                 </>
               )}
+              
+              {data.is_paid_event&&(registration?.has_paid_order || data.list_count >= data.limit) &&
+              <Link to = "https://www.facebook.com/groups/598608738731749/"><Button className='my-4 w-full'>{registration?.has_paid_order?"Selg billetten din her":"Sjekk om noen selger billett her"}</Button></Link>
+              }
+
+              
+      
             </CardContent>
           </Card>
 


### PR DESCRIPTION
## Description
Added a button for direct access to the facebook page on paid events. The text on the button changes to "sell ticket" when you've paid for the event, and "buy ticket" if you're on the waiting list.

closes #

Changes:

Screenshots:

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] The PR includes a picture showing visual changes
- [ ] Added Analytics-events if relevant
- [ ] CHANGELOG.md has been updated. [Guide](https://tihlde.slab.com/posts/changelog-z8hybjom)
