### PR TITLE
Refactor(gallery)/fix description width

### DIFF
--- a/src/pages/GalleryDetails/index.tsx
+++ b/src/pages/GalleryDetails/index.tsx
@@ -36,21 +36,19 @@ const GalleryDetails = () => {
       <div className='space-y-4 space-x-4 lg:space-y-0 lg:flex lg:items-center lg:justify-between'>
         <div className='space-y-4'>
           <div className='flex flex-row justify-between items-center'>
-          <h1 className='text-3xl lg:text-5xl font-bold'>{data?.title || 'Laster galleri...'}</h1>
+            <h1 className='text-3xl lg:text-5xl font-bold'>{data?.title || 'Laster galleri...'}</h1>
 
-          <HavePermission apps={[PermissionApp.PICTURE]}>
-          {data && (
-            <div className='flex items-center space-x-2'>
-              <PictureUpload id={data.id} />
-              <GalleryEditorDialog id={data.id} />
-            </div>
-          )}
-        </HavePermission>
+            <HavePermission apps={[PermissionApp.PICTURE]}>
+              {data && (
+                <div className='flex items-center space-x-2'>
+                  <PictureUpload id={data.id} />
+                  <GalleryEditorDialog id={data.id} />
+                </div>
+              )}
+            </HavePermission>
           </div>
           <p className='text-muted-foreground'>{data?.description}</p>
         </div>
-
-       
       </div>
 
       {data ? (

--- a/src/pages/GalleryDetails/index.tsx
+++ b/src/pages/GalleryDetails/index.tsx
@@ -34,7 +34,7 @@ const GalleryDetails = () => {
   return (
     <Page className='space-y-12'>
       <div className='space-y-4 space-x-4 lg:space-y-0 lg:flex lg:items-center lg:justify-between'>
-        <div className='space-y-4'>
+        <div className='space-y-4 w-full'>
           <div className='flex flex-row justify-between items-center'>
             <h1 className='text-3xl lg:text-5xl font-bold'>{data?.title || 'Laster galleri...'}</h1>
 

--- a/src/pages/GalleryDetails/index.tsx
+++ b/src/pages/GalleryDetails/index.tsx
@@ -35,7 +35,7 @@ const GalleryDetails = () => {
     <Page className='space-y-12'>
       <div className='space-y-4 space-x-4 lg:space-y-0 lg:flex lg:items-center lg:justify-between'>
         <div className='space-y-4 w-full'>
-          <div className='flex flex-row justify-between items-center'>
+          <div className='flex flex-col gap-2 md:flex-row md:justify-between md:items-center'>
             <h1 className='text-3xl lg:text-5xl font-bold'>{data?.title || 'Laster galleri...'}</h1>
 
             <HavePermission apps={[PermissionApp.PICTURE]}>

--- a/src/pages/GalleryDetails/index.tsx
+++ b/src/pages/GalleryDetails/index.tsx
@@ -33,13 +33,12 @@ const GalleryDetails = () => {
 
   return (
     <Page className='space-y-12'>
-      <div className='space-y-4 lg:space-y-0 lg:flex lg:items-center lg:justify-between'>
-        <div className='space-y-2'>
+      <div className='space-y-4 space-x-4 lg:space-y-0 lg:flex lg:items-center lg:justify-between'>
+        <div className='space-y-4'>
+          <div className='flex flex-row justify-between items-center'>
           <h1 className='text-3xl lg:text-5xl font-bold'>{data?.title || 'Laster galleri...'}</h1>
-          <p className='text-muted-foreground'>{data?.description}</p>
-        </div>
 
-        <HavePermission apps={[PermissionApp.PICTURE]}>
+          <HavePermission apps={[PermissionApp.PICTURE]}>
           {data && (
             <div className='flex items-center space-x-2'>
               <PictureUpload id={data.id} />
@@ -47,6 +46,11 @@ const GalleryDetails = () => {
             </div>
           )}
         </HavePermission>
+          </div>
+          <p className='text-muted-foreground'>{data?.description}</p>
+        </div>
+
+       
       </div>
 
       {data ? (


### PR DESCRIPTION
## Description

Added space between description and action buttons. Moved buttons to be in line with title.

closes #1113

Changes: 

Fixed the space between title, description and buttons on all types of screens. 

Screenshots: 
<img width="1182" alt="image" src="https://github.com/user-attachments/assets/6b70698f-5dd1-4e87-b38c-6b794e37843e">
<img width="519" alt="image" src="https://github.com/user-attachments/assets/44e0999c-1b67-422a-b870-2e227ba986de">


## Pull request checklist

Please check if your PR fulfills the following requirements:

- [x] The PR includes a picture showing visual changes
- [ ] Added Analytics-events if relevant
- [ ] CHANGELOG.md has been updated. [Guide](https://tihlde.slab.com/posts/changelog-z8hybjom)
