### PR TITLE
Refactor(gallery)/move pagination button below pictures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,9 @@
 ### 🎨 - Designendringer
 
 ## Neste versjon
+🎨 - **Desingendring**. Sentrerte og flyttet "Last in mer" knappen under bildene i galleri.  
 
 ## Versjon 2024.15.10
-
 - ✨ **Betalinger**. Man kan nå se hvem på deltagerlisten som har betalt for arrangementet.
 - 🎨 **Profil navigering**. Ikoner på mobil på profil er nå fikset.
 - 🎨 **Maks bredde på tekst**. Beskrivelse under tittel er nå tilpasset.

--- a/src/pages/GalleryDetails/components/GalleryRenderer.tsx
+++ b/src/pages/GalleryDetails/components/GalleryRenderer.tsx
@@ -1,17 +1,14 @@
 import { useMemo } from 'react';
 
 import { Gallery } from 'types';
+import { Picture } from 'types';
 
 import { useGalleryPictures } from 'hooks/Gallery';
-
-import { Picture } from 'types';
 
 import PictureDialog from 'pages/GalleryDetails/components/PictureDialog';
 
 import { PaginateButton } from 'components/ui/button';
 import { Skeleton } from 'components/ui/skeleton';
-
-
 
 export const GalleryRendererLoading = () => {
   return (
@@ -36,12 +33,9 @@ const GalleryRenderer = ({ id }: GalleryRendererProps) => {
         {pictures.map((image) => (
           <PictureDialog galleryId={id} key={image.id} picture={image} />
         ))}
-        {hasNextPage && <PaginateButton className='mt-4' isLoading={isFetching} nextPage={fetchNextPage} />}
       </div>
-
+      {hasNextPage && <PaginateButton className='mt-4' isLoading={isFetching} nextPage={fetchNextPage} />}
     </div>
-
-
   );
 };
 

--- a/src/pages/GalleryDetails/components/GalleryRenderer.tsx
+++ b/src/pages/GalleryDetails/components/GalleryRenderer.tsx
@@ -4,10 +4,14 @@ import { Gallery } from 'types';
 
 import { useGalleryPictures } from 'hooks/Gallery';
 
+import { Picture } from 'types';
+
 import PictureDialog from 'pages/GalleryDetails/components/PictureDialog';
 
 import { PaginateButton } from 'components/ui/button';
 import { Skeleton } from 'components/ui/skeleton';
+
+
 
 export const GalleryRendererLoading = () => {
   return (
@@ -26,14 +30,18 @@ export type GalleryRendererProps = {
 const GalleryRenderer = ({ id }: GalleryRendererProps) => {
   const { data, hasNextPage, fetchNextPage, isFetching } = useGalleryPictures(id);
   const pictures = useMemo(() => (data ? data.pages.map((page) => page.results).flat() : []), [data]);
-
   return (
-    <div className='grid md:grid-cols-2 lg:grid-cols-3 gap-4'>
-      {pictures.map((image) => (
-        <PictureDialog galleryId={id} key={image.id} picture={image} />
-      ))}
-      {hasNextPage && <PaginateButton className='w-full mt-4' isLoading={isFetching} nextPage={fetchNextPage} />}
+    <div className='flex flex-col justify-center items-center'>
+      <div className='grid md:grid-cols-2 lg:grid-cols-3 gap-4'>
+        {pictures.map((image) => (
+          <PictureDialog galleryId={id} key={image.id} picture={image} />
+        ))}
+        {hasNextPage && <PaginateButton className='mt-4' isLoading={isFetching} nextPage={fetchNextPage} />}
+      </div>
+
     </div>
+
+
   );
 };
 


### PR DESCRIPTION
## Description 
Fixed position of load more button in galleri 

closes #1111 

Changes: 
Placed button outside picture div, and centered it below the pictures. Can't test in localhost because there is no pictures in galleri. We tested with local pictures and the button was placed correctly. 

Screenshots:

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] The PR includes a picture showing visual changes
- [ ] Added Analytics-events if relevant
- [ ] CHANGELOG.md has been updated. [Guide](https://tihlde.slab.com/posts/changelog-z8hybjom)
