### PR TITLE
Showing only name in event admin on mobile

### DIFF
--- a/src/pages/EventAdministration/components/Participant.tsx
+++ b/src/pages/EventAdministration/components/Participant.tsx
@@ -99,7 +99,7 @@ const Participant = ({ registration, eventId }: ParticipantProps) => {
               <h1>
                 {registration.user_info.first_name} {registration.user_info.last_name}
               </h1>
-              <h1 className='text-sm'>{getUserAffiliation(registration.user_info)}</h1>
+              <h1 className='text-sm hidden md:block'>{getUserAffiliation(registration.user_info)}</h1>
             </div>
           </div>
           <div className='flex items-center space-x-2'>
@@ -146,7 +146,7 @@ const Participant = ({ registration, eventId }: ParticipantProps) => {
                 htmlFor={registration.user_info.user_id}>
                 <Checkbox checked={checkedState} id={registration.user_info.user_id} onCheckedChange={(checked) => handleAttendedCheck(Boolean(checked))} />
                 <div className='space-y-1 leading-none'>
-                  <Label>Ankommet?</Label>
+                  <Label>Ankommet? </Label>
                   <p className='text-sm text-muted-foreground'>Marker om deltager har ankommet</p>
                 </div>
               </label>


### PR DESCRIPTION
## Description
 Reduced the information to only name for registrations in event admin on mobile 

closes #1115 

Changes:
Now only the name is showing for registrations in event admin on mobile. 

Screenshots:
<img width="489" alt="image" src="https://github.com/user-attachments/assets/f7161588-7545-481c-8ccb-3eb5e6023568">


## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ x] The PR includes a picture showing visual changes
- [ ] Added Analytics-events if relevant
- [ ] CHANGELOG.md has been updated. [Guide](https://tihlde.slab.com/posts/changelog-z8hybjom)
