### PR TITLE
Feat(url shortener)/copy-button on url shortener

### DIFF
--- a/src/pages/ShortLinks/index.tsx
+++ b/src/pages/ShortLinks/index.tsx
@@ -27,6 +27,10 @@ type ShortLinkItemProps = {
 const ShortLinkItem = ({ shortLink }: ShortLinkItemProps) => {
   const deleteShortLink = useDeleteShortLink();
   const { event } = useAnalytics();
+  const clip = () => {
+    navigator.clipboard.writeText(`https://s.tihlde.org/${shortLink.name}`);
+    toast.success('Lenken ble kopiert til utklippstavlen');
+  };
   const { share } = useShare(
     {
       title: shortLink.name,
@@ -52,7 +56,7 @@ const ShortLinkItem = ({ shortLink }: ShortLinkItemProps) => {
       <CardHeader className='flex flex-row items-center justify-between'>
         <CardTitle>{shortLink.name}</CardTitle>
         <div>
-          <Button onClick={share} size='icon' variant='ghost'>
+          <Button onClick={clip} size='icon' variant='ghost'>
             <Copy />
           </Button>
           <Button onClick={share} size='icon' variant='ghost'>


### PR DESCRIPTION
## Description
Added a practical button for copying you shortened url link on the url-shortening page.

closes #1146

Changes:

Screenshots:

## Pull request checklist

<img width="475" alt="Skjermbilde 2024-10-28 kl  21 11 34" src="https://github.com/user-attachments/assets/c6ec9dad-d3ea-49be-9235-7e7a54114d7d">
<img width="1440" alt="Skjermbilde 2024-10-28 kl  21 11 45" src="https://github.com/user-attachments/assets/cf35abe5-2ca6-4ccf-a90a-ba54c09e2a7e">


Please check if your PR fulfills the following requirements:

- [x] The PR includes a picture showing visual changes
- [ ] Added Analytics-events if relevant
- [ ] CHANGELOG.md has been updated. [Guide](https://tihlde.slab.com/posts/changelog-z8hybjom)
