### PR TITLE
Parse paragraph numbers by prefixing a zero digit to a single digit decimal number

### DIFF
--- a/src/pages/Groups/laws/AddLawDialog.tsx
+++ b/src/pages/Groups/laws/AddLawDialog.tsx
@@ -3,6 +3,7 @@ import { Plus } from 'lucide-react';
 import { useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { toast } from 'sonner';
+import { parseLawParagraphNumber } from 'utils';
 import { z } from 'zod';
 
 import { Group } from 'types';
@@ -23,7 +24,7 @@ export type AddLawDialogProps = {
 const formSchema = z.object({
   amount: z.string(),
   description: z.string().optional(),
-  paragraph: z.string(),
+  paragraph: z.string().regex(/^\d+(\.\d{1,2})?$/, { message: 'Paragraf må være et tall med opptil to desimaler' }),
   title: z.string().min(1, { message: 'Tittel er påkrevd' }),
 });
 
@@ -45,7 +46,7 @@ const AddLawDialog = ({ groupSlug }: AddLawDialogProps) => {
     const data = {
       amount: parseInt(values.amount),
       description: values.description || '',
-      paragraph: parseFloat(values.paragraph),
+      paragraph: parseLawParagraphNumber(values.paragraph),
       title: values.title,
     };
     createLaw.mutate(data, {

--- a/src/pages/Groups/laws/LawItem.tsx
+++ b/src/pages/Groups/laws/LawItem.tsx
@@ -3,7 +3,7 @@ import { Pencil } from 'lucide-react';
 import { useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { toast } from 'sonner';
-import { formatLawHeader } from 'utils';
+import { formatLawHeader, parseLawParagraphNumber } from 'utils';
 import { z } from 'zod';
 
 import { Group, GroupLaw } from 'types';
@@ -27,7 +27,7 @@ export type LawItemProps = {
 const formSchema = z.object({
   amount: z.string(),
   description: z.string().optional(),
-  paragraph: z.string(),
+  paragraph: z.string().regex(/^\d+(\.\d{1,2})?$/, { message: 'Paragraf må være et tall med opptil to desimaler' }),
   title: z.string().min(1, { message: 'Tittel er påkrevd' }),
 });
 
@@ -61,7 +61,7 @@ const LawItem = ({ law, groupSlug, isAdmin = false }: LawItemProps) => {
     const data = {
       amount: parseInt(values.amount),
       description: values.description || '',
-      paragraph: parseFloat(values.paragraph),
+      paragraph: parseLawParagraphNumber(values.paragraph),
       title: values.title,
     };
     updateLaw.mutate(data, {

--- a/src/utils.tsx
+++ b/src/utils.tsx
@@ -364,3 +364,25 @@ export const removeIdsFromFields = (fields: Array<TextFormField | SelectFormFiel
  * @param url The URL to navigate to
  */
 export const navigateToExternalURL = (url: string) => window.open(url, '_blank');
+
+/**
+ * Parse a paragraph string to a number with two decimals at most and prefixed with a zero if it's a single digit decimal
+ *
+ * Examples:
+ * - "3" -> 3
+ * - "3.1" -> 3.01
+ * - "3.12" -> 3.12
+ *
+ * @param input The input string
+ * @returns The parsed number
+ */
+export const parseLawParagraphNumber = (input: string): number => {
+  const parts = input.split('.');
+  if (parts.length === 1) {
+    return parseFloat(input);
+  } else {
+    const integerPart = parts[0];
+    const decimalPart = parts[1].padStart(2, '0').slice(0, 2);
+    return parseFloat(`${integerPart}.${decimalPart}`);
+  }
+};


### PR DESCRIPTION
## Description
When writing a subparagraph law, if the number after the period is single digit, add a zero *before* the digit and not after.

For example:
- "3" -> 3
- "3.1" -> 3.01
- "3.12" -> 3.12

closes #1180

Changes:
Parse paragraph numbers by prefixing a zero digit to a single digit decimal number

Screenshots:

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] The PR includes a picture showing visual changes
- [ ] Added Analytics-events if relevant
- [x] CHANGELOG.md has been updated. [Guide](https://tihlde.slab.com/posts/changelog-z8hybjom)
