### PR TITLE
Automatically update fine amount when changing law broken

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@
 ### 🎨 - Designendringer
 
 ## Neste versjon
+- ⚡  **Lovparagraf**. Endret lovparagraf-parser for å prefikse enkeltsifrede desimaler med null.
+- 🦟 **Bøter**. Oppdater antall bøter ved endring av lovbrudd.
 
 ## Versjon 2024.04.11
 - 🎨 **Designendringer**. Gjort høyden på alle ulike gallerier lik, uavhengig av lengde på beskrivelse. 

--- a/src/pages/Groups/fines/AddFineDialog.tsx
+++ b/src/pages/Groups/fines/AddFineDialog.tsx
@@ -1,6 +1,6 @@
 import { zodResolver } from '@hookform/resolvers/zod';
 import { Plus } from 'lucide-react';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { toast } from 'sonner';
 import { formatLawHeader } from 'utils';
@@ -49,6 +49,17 @@ const AddFineDialog = ({ groupSlug }: AddFineDialogProps) => {
       image: '',
     },
   });
+
+  const selectedLawId = form.watch('description');
+
+  useEffect(() => {
+    if (selectedLawId && laws) {
+      const law = laws.find((law) => law.id === selectedLawId);
+      if (law) {
+        form.setValue('amount', law.amount.toString());
+      }
+    }
+  }, [selectedLawId, laws]);
 
   const onSubmit = (values: z.infer<typeof formSchema>) => {
     const law = laws?.find((law) => law.id === values.description);


### PR DESCRIPTION
## Description
Automatically update fine amount when changing law broken, and not just the first time a law is selected.

closes #1182

Changes:
Automatically update fine amount when changing law broken

Screenshots:

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] The PR includes a picture showing visual changes
- [ ] Added Analytics-events if relevant
- [x] CHANGELOG.md has been updated. [Guide](https://tihlde.slab.com/posts/changelog-z8hybjom)
