### PR TITLE
FIX: Removed allergy from group lists for those without permissions to write

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 ### 🎨 - Designendringer
 
 ## Neste versjon
-- 🦟 **Alergener** Fjernet allergener fra gruppe visning for de uten skrive rettigheter.
+- 🦟 **Allergener** Fjernet allergener fra gruppevisning for de uten skrive rettigheter.
 
 - 🦟 **Tilbakemeldinger** Fikset at popupen for tilbakemeldinger åpnes på nytt etter først gang.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### 🎨 - Designendringer
 
 ## Neste versjon
+- 🦟 **Alergener** Fjernet allergener fra gruppe visning for de uten skrive rettigheter.
 
 - 🦟 **Tilbakemeldinger** Fikset at popupen for tilbakemeldinger åpnes på nytt etter først gang.
 

--- a/src/pages/Groups/about/MembershipListItem.tsx
+++ b/src/pages/Groups/about/MembershipListItem.tsx
@@ -36,9 +36,11 @@ const MembershipListItem = ({ membership, isAdmin }: MembershipListItemProps) =>
       title={`${user.first_name} ${user.last_name}`}>
       <div className='space-y-4'>
         <div className='text-sm'>
-          <p>
-            <strong>Allergier:</strong> {user.allergy ? user.allergy : 'Har ingen allergier'}
-          </p>
+          {isAdmin && (
+            <p>
+              <strong>Allergier:</strong> {user.allergy ? user.allergy : 'Har ingen allergier'}
+            </p>
+          )}
           <p>
             <strong>E-post:</strong> {user.email}
           </p>


### PR DESCRIPTION
## Description

Allergies is a very personal. It shouldn't be shown to those that doesn't need to.

closes:
<img width="798" alt="image" src="https://github.com/user-attachments/assets/169b620f-a49f-492c-9d01-61e97c3b44fa" />


Changes:
Added conditional rendering depending if you have write permissions to the group.
This does not change the backend in any way. (didn't want to do any potential breaking changes).

NOTES:
The isAdmin param should probably be renamed to hasWritePermission.

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [x] The PR includes a picture showing visual changes
- [x] Added Analytics-events if relevant
- [x] CHANGELOG.md has been updated. [Guide](https://tihlde.slab.com/posts/changelog-z8hybjom)
