### PR TITLE
Fix Static button on groups and interest groups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ## Neste versjon
 
+- 🦟 **Interessegrupper/grupper** Fikset tilbakeknapp på interessegrupper, knappen er nå dynamisk
 - ⚡ **Andre Grupper** Fjernet "andre grupper" fra gruppelisten. 
 - ⚡ **Index Bug Popup** Fjernet index rydder opp popup-en.
 - 🦟 **Event Kort** Fikset slik at arrangement kort ikke overflyter til ny linje på hovedsiden

--- a/src/pages/Groups/GroupDetails.tsx
+++ b/src/pages/Groups/GroupDetails.tsx
@@ -66,7 +66,7 @@ export default function GroupPage({ loaderData }: Route.ComponentProps) {
 
           <div className='space-y-4 lg:space-y-0 lg:flex lg:items-center lg:justify-between'>
             <div className='flex items-center space-x-4'>
-              <GoBackButton url={href('/grupper')} />
+              <GoBackButton url={href(group.type === 'INTERESTGROUP' ? '/interessegrupper' : '/grupper')} />
               <div className='flex items-center space-x-2'>
                 <AspectRatioImg alt={group.image_alt ?? ''} className='h-[45px] w-[45px] md:h-[70px] md:w-[70px] rounded-md' src={group.image ?? ''} />
                 <h1 className='text-3xl md:text-5xl font-bold'>{group.name}</h1>


### PR DESCRIPTION
Fixed the button on groups and interest groups being redirected to the same page. Should be a dynamic button depending on if you are on a interest group page or a regular group. 

Changes:
* If condition on href to page redirect
* Checks if user is on interest group page, and reacts accordingly

Screenshots:
<img width="1009" height="209" alt="image" src="https://github.com/user-attachments/assets/a4bf91c4-a8f4-49fd-8dcc-29076511540f" />

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] The PR includes a picture showing visual changes
- [ ] Added Analytics-events if relevant
- [x] CHANGELOG.md has been updated. [Guide](https://tihlde.slab.com/posts/changelog-z8hybjom)
