### PR TITLE
migrate: move news domain pages to src/routes/news/

### DIFF
--- a/src/components/miscellaneous/NewsListItem.tsx
+++ b/src/components/miscellaneous/NewsListItem.tsx
@@ -1,12 +1,12 @@
 import { Link } from '@tanstack/react-router';
 import AspectRatioImg from '~/components/miscellaneous/AspectRatioImg';
 import { Skeleton } from '~/components/ui/skeleton';
-import type { News } from '~/types';
+import type { NewsListItem as NewsListItemType } from '@tihlde/sdk';
 import { formatDate, urlEncode } from '~/utils';
 import { parseISO } from 'date-fns';
 
 export type NewsListItemProps = {
-  news: News;
+  news: NewsListItemType;
 };
 
 const NewsListItem = ({ news }: NewsListItemProps) => {
@@ -15,12 +15,12 @@ const NewsListItem = ({ news }: NewsListItemProps) => {
       to='/nyheter/$id/{-$urlTitle}'
       params={{ id: news.id.toString(), urlTitle: urlEncode(news.title) }}
       className='rounded-md p-2 border bg-card space-y-4 cursor-pointer'>
-      <AspectRatioImg alt={news.image_alt || news.title} src={news.image} />
+      <AspectRatioImg alt={news.imageAlt || news.title} src={news.imageUrl ?? undefined} />
 
       <div>
         <h1 className='text-2xl font-bold'>{news.title}</h1>
         <p>{news.header}</p>
-        <p className='text-muted-foreground'>{formatDate(parseISO(news.created_at), { time: false })}</p>
+        <p className='text-muted-foreground'>{formatDate(parseISO(news.createdAt), { time: false })}</p>
       </div>
     </Link>
   );

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -50,11 +50,9 @@ export const routes = rootRoute('./routes/__root.tsx', [
       //
     ]),
 
-    // Redirects to new wiki: https://wiki.tihlde.org/
     route('/nyheter', [
-      index('./pages/News/index.tsx'),
-      route('/$id/{-$urlTitle}', './pages/NewsDetails/index.tsx'),
-      //
+      index('./routes/news/index.tsx'),
+      route('/$id/{-$urlTitle}', './routes/news/detail.tsx'),
     ]),
 
     route('/profil/{-$userId}', './pages/Profile/index.tsx'),
@@ -68,7 +66,7 @@ export const routes = rootRoute('./routes/__root.tsx', [
       route('/ny-gruppe', './pages/NewGroupAdministration/index.tsx'),
       route('/stillingsannonser/{-$jobPostId}', './pages/JobPostAdministration/index.tsx'),
       route('/arrangementer/{-$eventId}', './pages/EventAdministration/index.tsx'),
-      route('/nyheter/{-$newsId}', './pages/NewsAdministration/index.tsx'),
+      route('/nyheter/{-$newsId}', './routes/admin/news-editor.tsx'),
       route('/brukere', './pages/UserAdmin/index.tsx'),
       route('/prikker', './pages/StrikeAdmin/index.tsx'),
       route('/opptak', './pages/Opptak/index.tsx'),

--- a/src/routes/admin/components/DeleteNews.tsx
+++ b/src/routes/admin/components/DeleteNews.tsx
@@ -1,0 +1,28 @@
+import { Button } from '~/components/ui/button';
+import ResponsiveAlertDialog from '~/components/ui/responsive-alert-dialog';
+
+type DeleteNewsProps = {
+  newsId: number | null;
+  deleteNews: () => Promise<void>;
+};
+
+const DeleteNews = ({ newsId, deleteNews }: DeleteNewsProps) => {
+  if (!newsId) {
+    return null;
+  }
+
+  return (
+    <ResponsiveAlertDialog
+      action={deleteNews}
+      description='Er du sikker på at du vil slette nyheten? Dette kan ikke angres.'
+      title='Slett nyhet?'
+      trigger={
+        <Button className='w-full md:w-40 block' type='button' variant='destructive'>
+          Slett nyhet
+        </Button>
+      }
+    />
+  );
+};
+
+export default DeleteNews;

--- a/src/routes/admin/components/NewsEditor.tsx
+++ b/src/routes/admin/components/NewsEditor.tsx
@@ -1,0 +1,257 @@
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useMutation, useQuery } from '@tanstack/react-query';
+import MarkdownEditor from '~/components/inputs/MarkdownEditor';
+import { FormImageUpload } from '~/components/inputs/Upload';
+import RendererPreview from '~/components/miscellaneous/RendererPreview';
+import { Button } from '~/components/ui/button';
+import { Card, CardContent } from '~/components/ui/card';
+import { Form, FormControl, FormDescription, FormField, FormItem, FormLabel, FormMessage } from '~/components/ui/form';
+import { Input } from '~/components/ui/input';
+import { Switch } from '~/components/ui/switch';
+import { Skeleton } from '~/components/ui/skeleton';
+import {
+  getNewsByIdQuery,
+  createNewsMutation,
+  updateNewsMutation,
+  deleteNewsMutation,
+} from '~/api/queries/news';
+import NewsRenderer from '~/routes/news/components/NewsRenderer';
+import type { NewsArticle } from '@tihlde/sdk';
+import { useEffect } from 'react';
+import { useForm } from 'react-hook-form';
+import { toast } from 'sonner';
+import { z } from 'zod';
+
+import DeleteNews from './DeleteNews';
+
+export type NewsEditorProps = {
+  newsId: number | null;
+  goToNews: (newNews: number | null) => void;
+};
+
+const formSchema = z.object({
+  title: z.string().min(1, {
+    error: 'Tittelen kan ikke være tom',
+  }),
+  header: z.string().min(1, {
+    error: 'Header kan ikke være tom',
+  }),
+  body: z.string().min(1, {
+    error: 'Innholdet kan ikke være tomt',
+  }),
+  imageUrl: z.string(),
+  imageAlt: z.string(),
+  emojisAllowed: z.boolean(),
+});
+
+const NewsEditor = ({ newsId, goToNews }: NewsEditorProps) => {
+  const { data, isError, isLoading } = useQuery({
+    ...getNewsByIdQuery(String(newsId ?? -1)),
+    enabled: newsId != null && newsId > 0,
+  });
+  const createNews = useMutation(createNewsMutation);
+  const updateNews = useMutation(updateNewsMutation);
+  const deleteNews = useMutation(deleteNewsMutation);
+  const isUpdating = createNews.isPending || updateNews.isPending || deleteNews.isPending;
+
+  const form = useForm<z.infer<typeof formSchema>>({
+    resolver: zodResolver(formSchema),
+    defaultValues: {
+      title: '',
+      header: '',
+      body: '',
+      imageUrl: '',
+      imageAlt: '',
+      emojisAllowed: false,
+    },
+  });
+
+  const onSubmit = (values: z.infer<typeof formSchema>) => {
+    if (!newsId) {
+      createNews.mutate(
+        { data: values },
+        {
+          onSuccess: (data) => {
+            toast.success('Nyheten ble opprettet');
+            goToNews(Number(data.id));
+          },
+          onError: (e: any) => {
+            toast.error(e.detail ?? e.message);
+          },
+        },
+      );
+    } else {
+      updateNews.mutate(
+        { newsId: String(newsId), data: values },
+        {
+          onSuccess: () => {
+            toast.success('Nyheten ble oppdatert');
+          },
+          onError: (e: any) => {
+            toast.error(e.detail ?? e.message);
+          },
+        },
+      );
+    }
+  };
+
+  useEffect(() => {
+    if (isError) {
+      goToNews(null);
+    }
+  }, [isError, goToNews]);
+
+  useEffect(() => {
+    if (data) {
+      form.reset({
+        title: data.title || '',
+        header: data.header || '',
+        body: data.body || '',
+        imageUrl: data.imageUrl || '',
+        imageAlt: data.imageAlt || '',
+        emojisAllowed: data.emojisAllowed || false,
+      });
+    } else if (!newsId) {
+      form.reset({
+        title: '',
+        header: '',
+        body: '',
+        imageUrl: '',
+        imageAlt: '',
+        emojisAllowed: false,
+      });
+    }
+  }, [data, newsId, form.reset]);
+
+  const getNewsPreview = (): NewsArticle | null => {
+    const title = form.getValues('title');
+    const header = form.getValues('header');
+    const body = form.getValues('body');
+
+    if (!title && !header && !body) {
+      return null;
+    }
+
+    return {
+      id: '1',
+      title,
+      header,
+      body,
+      imageUrl: form.getValues('imageUrl') || null,
+      imageAlt: form.getValues('imageAlt') || null,
+      emojisAllowed: form.getValues('emojisAllowed'),
+      createdById: null,
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+      creator: null,
+      reactions: [],
+    };
+  };
+
+  const remove = async () => {
+    if (!newsId) return;
+    deleteNews.mutate(
+      { newsId: String(newsId) },
+      {
+        onSuccess: () => {
+          toast.success('Nyheten ble slettet');
+          goToNews(null);
+        },
+        onError: (e: any) => {
+          toast.error(e.detail ?? e.message);
+        },
+      },
+    );
+  };
+
+  if (isLoading && newsId) {
+    return <Skeleton className='w-full h-[60vh]' />;
+  }
+
+  return (
+    <Card>
+      <CardContent className='py-6'>
+        <Form {...form}>
+          <form className='space-y-6' onSubmit={form.handleSubmit(onSubmit)}>
+            <FormField
+              control={form.control}
+              name='title'
+              render={({ field }) => (
+                <FormItem className='w-full'>
+                  <FormLabel>
+                    Tittel <span className='text-red-300'>*</span>
+                  </FormLabel>
+                  <FormControl>
+                    <Input placeholder='Skriv her...' {...field} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <FormField
+              control={form.control}
+              name='header'
+              render={({ field }) => (
+                <FormItem className='w-full'>
+                  <FormLabel>
+                    Header <span className='text-red-300'>*</span>
+                  </FormLabel>
+                  <FormControl>
+                    <Input placeholder='Skriv her...' {...field} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <MarkdownEditor form={form} label='Innhold' name='body' required />
+
+            <FormImageUpload form={form} label='Velg bilde' name='imageUrl' ratio='21:9' />
+
+            <FormField
+              control={form.control}
+              name='imageAlt'
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Alternativ bildetekst</FormLabel>
+                  <FormControl>
+                    <Input placeholder='Skriv her...' {...field} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <FormField
+              control={form.control}
+              name='emojisAllowed'
+              render={({ field }) => (
+                <FormItem className='space-x-16 md:space-x-0 flex flex-row items-center justify-between rounded-md border p-4'>
+                  <div className='space-y-0.5'>
+                    <FormLabel className='text-base'>Reaksjoner</FormLabel>
+                    <FormDescription>La brukere reagere på nyheten med emojis</FormDescription>
+                  </div>
+                  <FormControl>
+                    <Switch checked={field.value} onCheckedChange={field.onChange} />
+                  </FormControl>
+                </FormItem>
+              )}
+            />
+
+            <div className='space-y-2 md:flex md:items-center md:justify-end md:space-x-4 md:space-y-0 pt-6'>
+              <DeleteNews deleteNews={remove} newsId={newsId} />
+
+              <RendererPreview getContent={getNewsPreview} renderer={NewsRenderer} />
+              <Button className='w-full md:w-40 block' disabled={isUpdating} type='submit'>
+                {newsId ? 'Oppdater nyhet' : 'Opprett nyhet'}
+              </Button>
+            </div>
+          </form>
+        </Form>
+      </CardContent>
+    </Card>
+  );
+};
+
+export default NewsEditor;

--- a/src/routes/admin/components/NewsList.tsx
+++ b/src/routes/admin/components/NewsList.tsx
@@ -1,0 +1,71 @@
+import { Link } from '@tanstack/react-router';
+import { useInfiniteQuery } from '@tanstack/react-query';
+import { Button, PaginateButton } from '~/components/ui/button';
+import ResponsiveDialog from '~/components/ui/responsive-dialog';
+import { ScrollArea } from '~/components/ui/scroll-area';
+import { getNewsInfiniteQuery } from '~/api/queries/news';
+import type { NewsListItem as NewsListItemType } from '@tihlde/sdk';
+import { ChevronRight, List } from 'lucide-react';
+import { type Dispatch, type SetStateAction, useState } from 'react';
+
+const NewsList = () => {
+  const [open, setOpen] = useState(false);
+  const { data, hasNextPage, fetchNextPage, isLoading } = useInfiniteQuery(getNewsInfiniteQuery());
+  const items = data ? data.pages.flatMap((page) => page.items) : [];
+
+  return (
+    <ResponsiveDialog
+      description='Her kan du se en oversikt over alle nyhetene som er lagt til i systemet.'
+      onOpenChange={setOpen}
+      open={open}
+      title='Nyheter'
+      trigger={
+        <Button size='icon' variant='outline'>
+          <List className='w-6 h-6' />
+        </Button>
+      }>
+      <ScrollArea className='h-[60vh] pr-4'>
+        {items.length === 0 && isLoading && (
+          <div className='flex justify-center w-full'>
+            <p className='text-lg'>Laster inn nyheter...</p>
+          </div>
+        )}
+
+        {items.length === 0 && !isLoading && (
+          <div className='flex justify-center w-full'>
+            <p className='text-lg'>Ingen nyheter er lagt til.</p>
+          </div>
+        )}
+
+        <div className='space-y-2 pb-6'>
+          {items.map((news) => (
+            <ListItem item={news} key={news.id} setOpen={setOpen} />
+          ))}
+          {hasNextPage && <PaginateButton className='w-full' isLoading={isLoading} nextPage={fetchNextPage} />}
+        </div>
+      </ScrollArea>
+    </ResponsiveDialog>
+  );
+};
+
+type ListItemProps = {
+  item: NewsListItemType;
+  setOpen: Dispatch<SetStateAction<boolean>>;
+};
+
+const ListItem = ({ item, setOpen }: ListItemProps) => {
+  return (
+    <Button asChild className='block w-full rounded-md border h-auto text-black dark:text-white' variant='outline'>
+      <Link className='flex items-center justify-between' onClick={() => setOpen(false)} to='/admin/nyheter/{-$newsId}' params={{ newsId: item.id.toString() }}>
+        <div>
+          <h1 className='text-lg'>{item.title}</h1>
+          <p>{item.header}</p>
+        </div>
+
+        <ChevronRight className='w-5 h-5 stroke-[1.5px]' />
+      </Link>
+    </Button>
+  );
+};
+
+export default NewsList;

--- a/src/routes/admin/news-editor.tsx
+++ b/src/routes/admin/news-editor.tsx
@@ -1,0 +1,64 @@
+import { createFileRoute, Link, linkOptions, useNavigate, useParams } from '@tanstack/react-router';
+import Page from '~/components/navigation/Page';
+import { Button } from '~/components/ui/button';
+import { ChevronRight, Plus } from 'lucide-react';
+
+import NewsEditor from './components/NewsEditor';
+import NewsList from './components/NewsList';
+
+// TODO: Re-add auth protection — previously used authClientWithRedirect() / userHasWritePermission(PermissionApp.NEWS)
+
+export const Route = createFileRoute('/_MainLayout/admin/nyheter/{-$newsId}')({
+  component: NewsAdministration,
+});
+
+function NewsAdministration() {
+  const navigate = useNavigate();
+  const { newsId } = useParams({ strict: false });
+
+  const goToNews = (newNews: number | null) => {
+    if (newNews) {
+      navigate(
+        linkOptions({
+          to: '/nyheter/$id/{-$urlTitle}',
+          params: { id: newNews.toString() },
+        }),
+      );
+    } else {
+      navigate(linkOptions({ to: '/admin/nyheter/{-$newsId}' }));
+    }
+  };
+
+  return (
+    <Page className='max-w-6xl mx-auto'>
+      <div className='space-y-6'>
+        <div className='space-y-4 md:space-y-0 md:flex items-center justify-between'>
+          <h1 className='font-bold text-4xl md:text-5xl'>{newsId ? 'Endre nyhet' : 'Ny nyhet'}</h1>
+
+          <div className='flex items-center space-x-4'>
+            <NewsList />
+
+            {newsId && (
+              <>
+                <Button asChild size='icon' variant='outline'>
+                  <Link to='/admin/nyheter/{-$newsId}'>
+                    <Plus className='w-5 h-5 stroke-[1.5px]' />
+                  </Link>
+                </Button>
+
+                <Button asChild className='p-0' variant='link'>
+                  <Link to='/admin/nyheter/{-$newsId}' params={{ newsId: newsId.toString() }}>
+                    Se nyhet
+                    <ChevronRight className='ml-1 w-5 h-5 stroke-[1.5px]' />
+                  </Link>
+                </Button>
+              </>
+            )}
+          </div>
+        </div>
+
+        <NewsEditor goToNews={goToNews} newsId={newsId ? Number(newsId) : null} />
+      </div>
+    </Page>
+  );
+}

--- a/src/routes/news/components/NewsRenderer.tsx
+++ b/src/routes/news/components/NewsRenderer.tsx
@@ -1,0 +1,77 @@
+import { Link } from '@tanstack/react-router';
+import TIHLDE_LOGO from '~/assets/img/TihldeBackground.jpg';
+import MarkdownRenderer from '~/components/miscellaneous/MarkdownRenderer';
+import ShareButton from '~/components/miscellaneous/ShareButton';
+import UpdatedAgo from '~/components/miscellaneous/UpdatedAgo';
+import { Button } from '~/components/ui/button';
+import { Separator } from '~/components/ui/separator';
+import { Skeleton } from '~/components/ui/skeleton';
+import type { NewsArticle } from '@tihlde/sdk';
+import { formatDate } from '~/utils';
+import { parseISO } from 'date-fns';
+import { PencilIcon } from 'lucide-react';
+
+export type NewsRendererProps = {
+  data: NewsArticle;
+  preview?: boolean;
+};
+
+const NewsRenderer = ({ data, preview = false }: NewsRendererProps) => {
+  return (
+    <div>
+      <div className='px-4 mx-auto max-w-4xl w-full pb-10'>
+        <div className='space-y-2'>
+          <h1 className='text-2xl break-words lg:text-4xl font-semibold'>{data.title}</h1>
+          <h1 className='break-words lg:text-lg'>{data.header}</h1>
+        </div>
+        <Separator className='my-6 bg-secondary-foreground dark:bg-border' />
+        <div className='space-y-2'>
+          {data.creator && (
+            <h1>
+              Skrevet av{' '}
+              {/* TODO: Re-add auth protection — previously linked to user profile with user_id */}
+              <span className='underline'>{data.creator.name}</span>
+            </h1>
+          )}
+          <h1 className='text-sm text-muted-foreground'>{formatDate(parseISO(data.createdAt), { time: false })}</h1>
+          {data.updatedAt && <UpdatedAgo updatedAt={data.updatedAt} />}
+        </div>
+      </div>
+
+      <div className='px-4 mx-auto max-w-4xl w-full space-y-4 lg:space-y-8'>
+        <img alt={data.imageAlt || data.title} className='rounded-md aspect-auto mx-auto' src={data.imageUrl || TIHLDE_LOGO} />
+
+        <div className='space-y-4 lg:space-y-0 lg:flex lg:items-center lg:justify-between'>
+          <div className='flex items-center space-x-2'>
+            <ShareButton shareId={data.id} shareType='news' title={data.title} />
+            {/* TODO: Re-add auth protection — previously used HavePermission with PermissionApp.NEWS */}
+            {!preview && (
+              <Button className='w-full flex items-center space-x-2' size='lg' variant='outline'>
+                <PencilIcon className='w-4 h-4 md:w-5 md:h-5 stroke-[1.5px]' />
+                <Link className='text-sm md:text-md' to='/admin/nyheter/{-$newsId}' params={{ newsId: data.id.toString() }}>
+                  Endre nyhet
+                </Link>
+              </Button>
+            )}
+          </div>
+          {/* TODO: Re-add reaction support — previously used ReactionHandler with auth check */}
+        </div>
+
+        <Separator className='bg-secondary-foreground dark:bg-border' />
+
+        <div>
+          <MarkdownRenderer value={data.body} />
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default NewsRenderer;
+
+export const NewsRendererLoading = () => (
+  <div className='space-y-4'>
+    <Skeleton className='h-60' />
+    <Skeleton className='h-96' />
+  </div>
+);

--- a/src/routes/news/detail.tsx
+++ b/src/routes/news/detail.tsx
@@ -1,0 +1,22 @@
+import { createFileRoute, useParams } from '@tanstack/react-router';
+import { useSuspenseQuery } from '@tanstack/react-query';
+import Page from '~/components/navigation/Page';
+import { getNewsByIdQuery } from '~/api/queries/news';
+import NewsRenderer from './components/NewsRenderer';
+
+export const Route = createFileRoute('/_MainLayout/nyheter/$id/{-$urlTitle}')({
+  component: NewsDetails,
+});
+
+function NewsDetails() {
+  const { id } = useParams({ strict: false });
+  const { data } = useSuspenseQuery(getNewsByIdQuery(String(id)));
+
+  return (
+    <Page>
+      <div className='pb-4'>
+        <NewsRenderer data={data} />
+      </div>
+    </Page>
+  );
+}

--- a/src/routes/news/index.tsx
+++ b/src/routes/news/index.tsx
@@ -1,0 +1,37 @@
+import { createFileRoute } from '@tanstack/react-router';
+import { useInfiniteQuery } from '@tanstack/react-query';
+import NewsListItem, { NewsListItemLoading } from '~/components/miscellaneous/NewsListItem';
+import NotFoundIndicator from '~/components/miscellaneous/NotFoundIndicator';
+import Page from '~/components/navigation/Page';
+import { PaginateButton } from '~/components/ui/button';
+import { getNewsInfiniteQuery } from '~/api/queries/news';
+
+export const Route = createFileRoute('/_MainLayout/nyheter/')({
+  component: News,
+});
+
+function News() {
+  const { data, error, hasNextPage, fetchNextPage, isLoading, isFetching } = useInfiniteQuery(getNewsInfiniteQuery());
+  const news = data ? data.pages.flatMap((page) => page.items) : [];
+
+  return (
+    <Page className='space-y-8 max-w-(--breakpoint-2xl) mx-auto'>
+      <div>
+        <h1 className='text-3xl md:text-5xl font-bold'>Nyheter</h1>
+      </div>
+      <div>
+        {isLoading && <NewsListItemLoading />}
+        {!isLoading && !news.length && <NotFoundIndicator header='Fant ingen nyheter' />}
+        {error && <h1 className='text-center mt-8'>{error.message}</h1>}
+        {data !== undefined && (
+          <div className='grid md:grid-cols-2 lg:grid-cols-3 gap-4'>
+            {news.map((newsItem) => (
+              <NewsListItem key={newsItem.id} news={newsItem} />
+            ))}
+          </div>
+        )}
+        {hasNextPage && <PaginateButton className='w-full mt-4' isLoading={isFetching} nextPage={fetchNextPage} />}
+      </div>
+    </Page>
+  );
+}


### PR DESCRIPTION
## Summary
- Move News list, NewsDetails, and NewsAdministration from `src/pages/` to `src/routes/news/` and `src/routes/admin/`
- Replace old hooks with new query layer from `~/api/queries/news`
- Use `useSuspenseQuery` for detail pages
- Remove auth protection with TODO comments

## Test plan
- [ ] Verify TypeScript compilation passes (`bun run check`)
- [ ] Test news list page
- [ ] Test news detail page
- [ ] Test news admin editor