### PR TITLE
migrate: move events domain pages to src/routes/events/

### DIFF
--- a/src/routes.ts
+++ b/src/routes.ts
@@ -9,10 +9,9 @@ export const routes = rootRoute('./routes/__root.tsx', [
     route('tilbakemelding', './pages/Feedback/index.tsx'),
 
     route('/arrangementer', [
-      index('./pages/Events/index.tsx'),
-      // INFO: This route has been re-written from :id/registrering
-      route('/registrering/$id', './pages/EventRegistration/index.tsx'),
-      route('/$id/{-$urlTitle}', './pages/EventDetails/index.tsx'),
+      index('./routes/events/index.tsx'),
+      route('/registrering/$id', './routes/events/registration.tsx'),
+      route('/$id/{-$urlTitle}', './routes/events/detail.tsx'),
     ]),
     route('/bedrifter', './pages/Companies/index.tsx'),
     route('/toddel', './pages/Toddel/index.tsx'),

--- a/src/routes/events/components/ActivitiesDefaultView.tsx
+++ b/src/routes/events/components/ActivitiesDefaultView.tsx
@@ -1,0 +1,5 @@
+import EventFilterView from './EventFilterView';
+
+const ActivitiesDefaultView = () => <EventFilterView activityMode />;
+
+export default ActivitiesDefaultView;

--- a/src/routes/events/components/EventFilterView.tsx
+++ b/src/routes/events/components/EventFilterView.tsx
@@ -1,0 +1,415 @@
+import { useInfiniteQuery } from '@tanstack/react-query';
+import { useNavigate } from '@tanstack/react-router';
+import NotFoundIndicator from '~/components/miscellaneous/NotFoundIndicator';
+import { Badge } from '~/components/ui/badge';
+import { Button, PaginateButton } from '~/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '~/components/ui/card';
+import Expandable from '~/components/ui/expandable';
+import { Form, FormControl, FormDescription, FormField, FormItem, FormLabel, FormMessage } from '~/components/ui/form';
+import { Input } from '~/components/ui/input';
+import { Separator } from '~/components/ui/separator';
+import { Switch } from '~/components/ui/switch';
+import { getEventsInfiniteQuery } from '~/api/queries/events';
+import { useAuthQuery } from '~/hooks/auth';
+import { useAnalytics } from '~/hooks/Utils';
+import { argsToParams } from '~/utils';
+import EventListCard, { EventListCardLoading } from './EventListCard';
+import { FilterX, Search, SlidersHorizontal } from 'lucide-react';
+import { useMemo, useState } from 'react';
+import { useForm } from 'react-hook-form';
+import { z } from 'zod';
+
+type Filters = {
+  search?: string;
+  category?: string;
+  open_for_sign_up?: boolean;
+  user_favorite?: boolean;
+  expired: boolean;
+  activity?: boolean;
+};
+
+const formSchema = z.object({
+  search: z.string().optional(),
+  category: z.string().optional(),
+  open_for_sign_up: z.boolean().optional(),
+  user_favorite: z.boolean().optional(),
+  expired: z.boolean(),
+  activity: z.boolean().optional(),
+});
+
+type EventFilterViewProps = {
+  /** Force activity filter on (for the activities tab) */
+  activityMode?: boolean;
+  labels?: {
+    filterDescription: string;
+    expiredDescription: string;
+    signUpDescription: string;
+    emptyMessage: string;
+    resultSingular: string;
+    resultPlural: string;
+  };
+};
+
+const DEFAULT_LABELS = {
+  filterDescription: 'Filtrer arrangementer',
+  expiredDescription: 'Vis tidligere arrangementer',
+  signUpDescription: 'Vis kun arrangementer med apen pamelding',
+  emptyMessage: 'Fant ingen arrangementer',
+  resultSingular: 'arrangement',
+  resultPlural: 'arrangementer',
+};
+
+const ACTIVITY_LABELS = {
+  filterDescription: 'Filtrer aktiviteter',
+  expiredDescription: 'Vis tidligere aktiviteter',
+  signUpDescription: 'Vis kun aktiviteter med apen pamelding',
+  emptyMessage: 'Fant ingen aktiviteter',
+  resultSingular: 'aktivitet',
+  resultPlural: 'aktiviteter',
+};
+
+function getInitialFilters(activityMode: boolean): Filters {
+  const params = new URLSearchParams(location.search);
+  const expired = params.get('expired') === 'true';
+  const open_for_sign_up = params.get('open_for_sign_up') ? params.get('open_for_sign_up') === 'true' : undefined;
+  const user_favorite = params.get('user_favorite') ? params.get('user_favorite') === 'true' : undefined;
+  const category = activityMode ? undefined : params.get('category') || undefined;
+  const search = params.get('search') || undefined;
+  return { expired, category, search, open_for_sign_up, user_favorite, activity: activityMode || false };
+}
+
+const EventFilterView = ({ activityMode = false, labels: labelOverrides }: EventFilterViewProps) => {
+  const labels = labelOverrides ?? (activityMode ? ACTIVITY_LABELS : DEFAULT_LABELS);
+  const { auth } = useAuthQuery();
+  const isAuthenticated = auth != null;
+  const { event: analyticsEvent } = useAnalytics();
+  const navigate = useNavigate();
+
+  const [initialFilters] = useState(() => getInitialFilters(activityMode));
+  const [filters, setFilters] = useState<Filters>(initialFilters);
+  const { data, error, hasNextPage, fetchNextPage, isLoading, isFetching } = useInfiniteQuery(getEventsInfiniteQuery(filters));
+  const events = useMemo(() => (data ? data.pages.flatMap((page) => page.items) : []), [data]);
+  const isEmpty = useMemo(() => (data !== undefined ? !data.pages.some((page) => Boolean(page.items.length)) : false), [data]);
+  const form = useForm<z.infer<typeof formSchema>>({ defaultValues: initialFilters });
+
+  const [searchFormExpanded, setSearchFormExpanded] = useState(false);
+
+  const resetFilters = () => {
+    form.setValue('category', '');
+    form.setValue('search', '');
+    form.setValue('expired', false);
+    form.setValue('user_favorite', false);
+    form.setValue('open_for_sign_up', false);
+    const reset: Filters = { expired: false, open_for_sign_up: false, user_favorite: false, activity: activityMode };
+    setFilters(reset);
+    navigate({ href: `${location.pathname}${argsToParams({ expired: false })}`, replace: true });
+  };
+
+  const onSearch = (values: z.infer<typeof formSchema>) => {
+    const searchValues = activityMode ? { ...values, activity: true } : values;
+    analyticsEvent('search', activityMode ? 'activities' : 'events', JSON.stringify(searchValues));
+    setFilters(searchValues);
+    if (activityMode) {
+      navigate({ href: `${location.pathname}${argsToParams(searchValues)}`, replace: true });
+    }
+    setSearchFormExpanded(false);
+  };
+
+  const hasActiveFilters = Boolean(filters.search || filters.category || filters.expired || filters.open_for_sign_up || filters.user_favorite);
+  const activeFilterCount = [filters.search, filters.category, filters.expired, filters.open_for_sign_up, filters.user_favorite].filter(Boolean).length;
+
+  return (
+    <div className='grid lg:grid-cols-[400px_1fr] gap-6 items-start'>
+      <div>
+        {/* Desktop: always-visible card */}
+        <div className='hidden lg:block'>
+          <Card className='shadow-xs'>
+            <CardHeader className='pb-3 border-b'>
+              <div className='flex justify-between items-center'>
+                <div className='flex items-center gap-2'>
+                  <CardTitle className='text-lg font-medium'>Filter</CardTitle>
+                  {hasActiveFilters && (
+                    <Badge className='ml-2' variant='secondary'>
+                      {activeFilterCount}
+                    </Badge>
+                  )}
+                </div>
+                {hasActiveFilters && (
+                  <Button aria-label='Nullstill filter' className='h-8 px-2' onClick={resetFilters} size='sm' variant='ghost'>
+                    <FilterX className='mr-1' size={18} />
+                    <span className='text-sm'>Nullstill</span>
+                  </Button>
+                )}
+              </div>
+            </CardHeader>
+            <CardContent className='p-4'>
+              <SearchForm
+                form={form}
+                onSubmit={onSearch}
+                isFetching={isFetching}
+                isAuthenticated={isAuthenticated}
+                showCategory={!activityMode}
+                labels={labels}
+              />
+            </CardContent>
+          </Card>
+        </div>
+        {/* Mobile: expandable panel */}
+        <div className='lg:hidden'>
+          <Expandable
+            description={labels.filterDescription}
+            icon={<SlidersHorizontal className='w-5 h-5 stroke-[1.5px]' />}
+            onOpenChange={setSearchFormExpanded}
+            open={searchFormExpanded}
+            title={
+              <div className='flex items-center gap-2'>
+                <span>Filter</span>
+                {hasActiveFilters && (
+                  <Badge className='ml-1' variant='secondary'>
+                    {activeFilterCount}
+                  </Badge>
+                )}
+              </div>
+            }>
+            <div className='pt-4'>
+              <SearchForm
+                form={form}
+                onSubmit={onSearch}
+                isFetching={isFetching}
+                isAuthenticated={isAuthenticated}
+                showCategory={!activityMode}
+                labels={labels}
+              />
+            </div>
+          </Expandable>
+        </div>
+      </div>
+
+      <div className='space-y-4'>
+        {hasActiveFilters && (
+          <ActiveFilterBadges filters={filters} form={form} onSearch={onSearch} activityMode={activityMode} />
+        )}
+
+        {data !== undefined && (
+          <div className='flex justify-between items-center mb-4'>
+            <h2 className='text-lg font-medium'>
+              {events.length} {events.length === 1 ? labels.resultSingular : labels.resultPlural} funnet
+            </h2>
+          </div>
+        )}
+
+        {isLoading && <EventListCardLoading />}
+        {isEmpty && <NotFoundIndicator header={labels.emptyMessage} />}
+        {error && (
+          <div className='text-center py-12 bg-muted/30 rounded-lg'>
+            <h3 className='text-xl font-medium mb-2'>Noe gikk galt</h3>
+            <p className='text-muted-foreground'>{String(error)}</p>
+          </div>
+        )}
+
+        {data !== undefined && (
+          <div className='space-y-4'>
+            {events.map((event) => (
+              <EventListCard event={event} key={event.id} />
+            ))}
+          </div>
+        )}
+
+        {hasNextPage && <PaginateButton className='w-full mt-6' isLoading={isFetching} nextPage={fetchNextPage} />}
+      </div>
+    </div>
+  );
+};
+
+export default EventFilterView;
+
+// --- Extracted sub-components (not inline to avoid remounting) ---
+
+type SearchFormProps = {
+  form: ReturnType<typeof useForm<z.infer<typeof formSchema>>>;
+  onSubmit: (values: z.infer<typeof formSchema>) => void;
+  isFetching: boolean;
+  isAuthenticated: boolean;
+  showCategory: boolean;
+  labels: typeof DEFAULT_LABELS;
+};
+
+function SearchForm({ form, onSubmit, isFetching, isAuthenticated, labels }: SearchFormProps) {
+  return (
+    <Form {...form}>
+      <form className='space-y-6' onSubmit={form.handleSubmit(onSubmit)}>
+        <FormField
+          control={form.control}
+          name='search'
+          render={({ field }) => (
+            <FormItem className='space-y-2'>
+              <FormLabel className='text-sm font-medium'>Sok</FormLabel>
+              <div className='flex gap-2'>
+                <FormControl>
+                  <Input {...field} className='flex-1' placeholder='Skriv her...' />
+                </FormControl>
+              </div>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+
+        <Separator />
+
+        {/* TODO: Re-add category select — previously used useCategories() which is no longer available */}
+
+        <div className='space-y-3'>
+          <h3 className='text-sm font-medium'>Alternativer</h3>
+
+          <FormField
+            control={form.control}
+            name='expired'
+            render={({ field }) => (
+              <FormItem className='flex flex-row items-center justify-between rounded-lg bg-muted/50 p-3'>
+                <div className='space-y-0.5'>
+                  <FormLabel className='text-sm font-medium'>Tidligere</FormLabel>
+                  <FormDescription className='text-xs'>{labels.expiredDescription}</FormDescription>
+                </div>
+                <FormControl>
+                  <Switch checked={field.value} onCheckedChange={field.onChange} />
+                </FormControl>
+              </FormItem>
+            )}
+          />
+
+          <FormField
+            control={form.control}
+            name='open_for_sign_up'
+            render={({ field }) => (
+              <FormItem className='flex flex-row items-center justify-between rounded-lg bg-muted/50 p-3'>
+                <div className='space-y-0.5'>
+                  <FormLabel className='text-sm font-medium'>Apen pamelding</FormLabel>
+                  <FormDescription className='text-xs'>{labels.signUpDescription}</FormDescription>
+                </div>
+                <FormControl>
+                  <Switch checked={field.value} onCheckedChange={field.onChange} />
+                </FormControl>
+              </FormItem>
+            )}
+          />
+
+          {isAuthenticated && (
+            <FormField
+              control={form.control}
+              name='user_favorite'
+              render={({ field }) => (
+                <FormItem className='flex flex-row items-center justify-between rounded-lg bg-muted/50 p-3'>
+                  <div className='space-y-0.5'>
+                    <FormLabel className='text-sm font-medium'>Favoritter</FormLabel>
+                    <FormDescription className='text-xs'>Vis kun dine favoritter</FormDescription>
+                  </div>
+                  <FormControl>
+                    <Switch checked={field.value} onCheckedChange={field.onChange} />
+                  </FormControl>
+                </FormItem>
+              )}
+            />
+          )}
+          <Button aria-label='Sok' className='w-full' disabled={isFetching} type='submit'>
+            {isFetching ? (
+              <span className='animate-spin'>&#x27F3;</span>
+            ) : (
+              <div className='flex items-center gap-1'>
+                <Search className='h-4 w-4' />
+                <span>Sok</span>
+              </div>
+            )}
+          </Button>
+        </div>
+      </form>
+    </Form>
+  );
+}
+
+type ActiveFilterBadgesProps = {
+  filters: Filters;
+  form: ReturnType<typeof useForm<z.infer<typeof formSchema>>>;
+  onSearch: (values: z.infer<typeof formSchema>) => void;
+  activityMode: boolean;
+};
+
+function ActiveFilterBadges({ filters, form, onSearch, activityMode }: ActiveFilterBadgesProps) {
+  return (
+    <div className='flex flex-wrap gap-2 mb-4'>
+      {filters.search && (
+        <Badge className='flex items-center gap-1 px-3 py-1' variant='outline'>
+          <span>Sok: {filters.search}</span>
+          <button
+            aria-label='Fjern sokefilter'
+            className='ml-1 hover:bg-secondary rounded-full p-1'
+            onClick={() => {
+              form.setValue('search', '');
+              onSearch({ ...filters, search: '' });
+            }}>
+            <FilterX size={14} />
+          </button>
+        </Badge>
+      )}
+
+      {filters.category && (
+        <Badge className='flex items-center gap-1 px-3 py-1' variant='outline'>
+          <span>Kategori: {filters.category}</span>
+          <button
+            aria-label='Fjern kategorifilter'
+            className='ml-1 hover:bg-secondary rounded-full p-1'
+            onClick={() => {
+              form.setValue('category', '');
+              onSearch({ ...filters, category: '' });
+            }}>
+            <FilterX size={14} />
+          </button>
+        </Badge>
+      )}
+
+      {filters.expired && (
+        <Badge className='flex items-center gap-1 px-3 py-1' variant='outline'>
+          <span>{activityMode ? 'Tidligere aktiviteter' : 'Tidligere arrangementer'}</span>
+          <button
+            aria-label='Fjern tidligere filter'
+            className='ml-1 hover:bg-secondary rounded-full p-1'
+            onClick={() => {
+              form.setValue('expired', false);
+              onSearch({ ...filters, expired: false });
+            }}>
+            <FilterX size={14} />
+          </button>
+        </Badge>
+      )}
+
+      {filters.open_for_sign_up && (
+        <Badge className='flex items-center gap-1 px-3 py-1' variant='outline'>
+          <span>Apen pamelding</span>
+          <button
+            aria-label='Fjern apen pamelding filter'
+            className='ml-1 hover:bg-secondary rounded-full p-1'
+            onClick={() => {
+              form.setValue('open_for_sign_up', false);
+              onSearch({ ...filters, open_for_sign_up: false });
+            }}>
+            <FilterX size={14} />
+          </button>
+        </Badge>
+      )}
+
+      {filters.user_favorite && (
+        <Badge className='flex items-center gap-1 px-3 py-1' variant='outline'>
+          <span>Favoritter</span>
+          <button
+            aria-label='Fjern favoritter filter'
+            className='ml-1 hover:bg-secondary rounded-full p-1'
+            onClick={() => {
+              form.setValue('user_favorite', false);
+              onSearch({ ...filters, user_favorite: false });
+            }}>
+            <FilterX size={14} />
+          </button>
+        </Badge>
+      )}
+    </div>
+  );
+}

--- a/src/routes/events/components/EventListCard.tsx
+++ b/src/routes/events/components/EventListCard.tsx
@@ -1,0 +1,66 @@
+import { Link } from '@tanstack/react-router';
+import { Card, CardContent } from '~/components/ui/card';
+import { Skeleton } from '~/components/ui/skeleton';
+import { urlEncode } from '~/utils';
+import { Calendar, MapPin } from 'lucide-react';
+import { format, parseISO } from 'date-fns';
+import { nb } from 'date-fns/locale';
+
+type EventItem = {
+  id: string;
+  title: string;
+  image: string | null;
+  startTime: string;
+  endTime: string;
+  location?: string | null;
+  category: { slug: string; label: string };
+  organizer: { name: string; slug: string; type: string } | null;
+};
+
+export type EventListCardProps = {
+  event: EventItem;
+};
+
+const EventListCard = ({ event }: EventListCardProps) => {
+  const startDate = parseISO(event.startTime);
+
+  return (
+    <Link to='/arrangementer/$id/{-$urlTitle}' params={{ id: event.id, urlTitle: urlEncode(event.title) }}>
+      <Card className='overflow-hidden hover:bg-accent/50 transition-colors'>
+        <CardContent className='flex gap-4 p-0'>
+          {event.image && (
+            <img
+              alt={event.title}
+              className='w-[150px] md:w-[200px] lg:w-[250px] object-cover aspect-[4/3]'
+              src={event.image}
+            />
+          )}
+          <div className='flex flex-col justify-center gap-1.5 py-3 pr-4 min-w-0'>
+            <h3 className='font-semibold text-sm md:text-lg truncate'>{event.title}</h3>
+            <div className='flex items-center gap-1.5 text-xs md:text-sm text-muted-foreground'>
+              <Calendar className='w-3.5 h-3.5 shrink-0' />
+              <span>{format(startDate, 'dd. MMM yyyy, HH:mm', { locale: nb })}</span>
+            </div>
+            {event.location && (
+              <div className='flex items-center gap-1.5 text-xs md:text-sm text-muted-foreground'>
+                <MapPin className='w-3.5 h-3.5 shrink-0' />
+                <span className='truncate'>{event.location}</span>
+              </div>
+            )}
+            <span className='text-xs text-muted-foreground'>{event.category.label}</span>
+          </div>
+        </CardContent>
+      </Card>
+    </Link>
+  );
+};
+
+export default EventListCard;
+
+export const EventListCardLoading = () => (
+  <div className='space-y-4'>
+    {Array.from({ length: 4 }).map((_, i) => (
+      <Skeleton key={i} className='w-full h-24 rounded-lg' />
+    ))}
+  </div>
+);

--- a/src/routes/events/components/EventRenderer.tsx
+++ b/src/routes/events/components/EventRenderer.tsx
@@ -1,0 +1,295 @@
+import { useMutation } from '@tanstack/react-query';
+import { Link } from '@tanstack/react-router';
+import TIHLDE_LOGO from '~/assets/img/TihldeBackground.jpg';
+import DetailContent from '~/components/miscellaneous/DetailContent';
+import ShareButton from '~/components/miscellaneous/ShareButton';
+import UpdatedAgo from '~/components/miscellaneous/UpdatedAgo';
+import { Alert, AlertDescription } from '~/components/ui/alert';
+import { Button } from '~/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '~/components/ui/card';
+import Expandable from '~/components/ui/expandable';
+import { Skeleton } from '~/components/ui/skeleton';
+import {
+  registerForEventMutation,
+  unregisterFromEventMutation,
+  updateFavoriteEventMutation,
+} from '~/api/queries/events';
+import { useOptionalAuth } from '~/hooks/auth';
+import { useAnalytics } from '~/hooks/Utils';
+import ResponsiveAlertDialog from '~/components/ui/responsive-alert-dialog';
+import { formatDate } from '~/utils';
+import { parseISO } from 'date-fns';
+import { Heart, LoaderCircle } from 'lucide-react';
+import { cn } from '~/lib/utils';
+import { toast } from 'sonner';
+import type { paths } from '@tihlde/sdk';
+
+type Event = paths['/api/event/{eventId}']['get'] extends { responses: { 200: { content: { 'application/json': infer T } } } } ? T : never;
+
+export type EventRendererProps = {
+  data: Event;
+  preview?: boolean;
+};
+
+const EventRenderer = ({ data, preview = false }: EventRendererProps) => {
+  const { event: analyticsEvent } = useAnalytics();
+  const { auth } = useOptionalAuth();
+  const user = auth?.user ?? null;
+
+  const startDate = parseISO(data.startTime);
+  const endDate = parseISO(data.endTime);
+
+  const registerMutation = useMutation(registerForEventMutation);
+  const unregisterMutation = useMutation(unregisterFromEventMutation);
+  const favoriteMutation = useMutation(updateFavoriteEventMutation);
+
+  // TODO: Re-add confetti on sign up — previously used useConfetti()
+
+  const signUp = () => {
+    registerMutation.mutate(
+      { eventId: data.id },
+      {
+        onSuccess: () => {
+          toast.success('Pameldingen var vellykket');
+          analyticsEvent('registered', 'event-registration', `Registered for event: ${data.title}`);
+        },
+        onError: (e) => {
+          toast.error(String(e));
+        },
+      },
+    );
+  };
+
+  const signOff = () => {
+    unregisterMutation.mutate(
+      { eventId: data.id },
+      {
+        onSuccess: () => {
+          toast.success('Du er avmeldt arrangementet');
+          analyticsEvent('unregistered', 'event-registration', `Unregistered for event: ${data.title}`);
+        },
+        onError: (e) => {
+          toast.error(String(e));
+        },
+      },
+    );
+  };
+
+  const registrationInfo = (() => {
+    const reg = data.registration;
+    if (!reg) return null;
+
+    if (reg.status === 'waitlisted') {
+      return (
+        <Alert>
+          <AlertDescription>
+            Du star pa plass {reg.waitlistPosition ?? '?'} pa ventelisten, vi gir deg beskjed hvis du far plass
+          </AlertDescription>
+        </Alert>
+      );
+    }
+
+    if (reg.status === 'registered' || reg.status === 'attended') {
+      return (
+        <Alert variant='success'>
+          <AlertDescription>
+            {reg.status === 'attended' ? 'Du har deltatt pa arrangementet!' : 'Du har plass pa arrangementet!'}
+          </AlertDescription>
+        </Alert>
+      );
+    }
+
+    return null;
+  })();
+
+  const applyInfo = (() => {
+    if (preview) return null;
+    if (data.closed) {
+      return (
+        <Alert variant='warning'>
+          <AlertDescription>Dette arrangementet er stengt. Det er derfor ikke mulig a melde seg av eller pa.</AlertDescription>
+        </Alert>
+      );
+    }
+
+    if (data.registration) {
+      return (
+        <>
+          {registrationInfo}
+          {data.registration.status !== 'cancelled' && (
+            <ResponsiveAlertDialog
+              action={signOff}
+              description='Om du melder deg av arrangementet vil du miste plassen din og eventuelt havne pa venteliste om det er en.'
+              title='Meld deg av arrangementet'
+              trigger={
+                <Button className='w-full' variant='destructive'>
+                  Meld deg av
+                </Button>
+              }
+            />
+          )}
+        </>
+      );
+    }
+
+    if (!user) {
+      return (
+        <Button className='w-full' size='lg' variant='default' asChild>
+          <Link to='/logg-inn' search={{ redirectTo: typeof window !== 'undefined' ? window.location.pathname : '' }}>
+            Logg inn for a melde deg pa
+          </Link>
+        </Button>
+      );
+    }
+
+    // TODO: Re-add unanswered evaluations check — previously checked user.unanswered_evaluations_count
+    // TODO: Re-add priority pool check — previously checked only_allow_prioritized
+    return (
+      <Button className='w-full' disabled={registerMutation.isPending} onClick={signUp} size='lg'>
+        {registerMutation.isPending ? <LoaderCircle className='w-5 h-5 animate-spin' /> : 'Meld deg pa'}
+      </Button>
+    );
+  })();
+
+  const toggleFavorite = () => {
+    // TODO: Re-add individual favorite status check — previously used useEventIsFavorite()
+    // The new API only has updateFavoriteEvent (PUT) and getFavoriteEvents (list all), no GET for single event
+    analyticsEvent('mark-as-favorite', 'event', `Marked event (${data.title}) as favorite`);
+    favoriteMutation.mutate(
+      { eventId: data.id, data: { isFavorite: true } },
+      {
+        onSuccess: () => {
+          toast.success('Arrangementet er na en av dine favoritter.');
+        },
+        onError: (e) => {
+          toast.error(String(e));
+        },
+      },
+    );
+  };
+
+  const info = (
+    <>
+      <Card>
+        <CardHeader className='py-1 px-4'>
+          <CardTitle className='flex items-center justify-between'>
+            <h1>Detaljer</h1>
+            {user && !preview && (
+              <Button onClick={toggleFavorite} size='icon' variant='ghost' disabled={favoriteMutation.isPending}>
+                <Heart className={cn('w-5 h-5 stroke-[1.5px]')} />
+              </Button>
+            )}
+          </CardTitle>
+        </CardHeader>
+        <CardContent className='py-2 px-4 space-y-3'>
+          <DetailContent info={formatDate(startDate)} title='Fra:' />
+          <DetailContent info={formatDate(endDate)} title='Til:' />
+          {data.location && <DetailContent info={data.location} title='Sted:' />}
+          <DetailContent info={data.category.label} title='Hva:' />
+          {data.organizer && (
+            <DetailContent
+              info={
+                <Link to='/grupper/$slug' params={{ slug: data.organizer.slug }}>
+                  {data.organizer.name}
+                </Link>
+              }
+              title='Arrangor:'
+            />
+          )}
+          {data.payInfo && <DetailContent info={data.payInfo.price + ' kr'} title='Pris:' />}
+        </CardContent>
+      </Card>
+
+      {Boolean(data.priorityPools.length) && (
+        <Card>
+          <CardHeader className='py-3 px-4'>
+            <CardTitle>
+              <h1>Prioritert</h1>
+            </CardTitle>
+          </CardHeader>
+          <CardContent className='py-2 px-4'>
+            <div className='space-y-2'>
+              {data.priorityPools.map((pool, index) => (
+                <Card className='rounded-sm' key={index}>
+                  <CardContent className='py-1 px-2'>
+                    <h1 className='text-xs'>{pool.groups.map((g) => g.name).join(' og ')}</h1>
+                  </CardContent>
+                </Card>
+              ))}
+              <Expandable title='Hvordan fungerer prioritering?'>
+                <p className='text-sm text-muted-foreground'>
+                  Boksene ovenfor viser dette arrangementets prioriteringsgrupper. Du er prioritert om du er medlem av
+                  alle gruppene i en av prioriteringsgruppene. Rekkefolgene til gruppene har ingenting a si.
+                </p>
+              </Expandable>
+            </div>
+          </CardContent>
+        </Card>
+      )}
+
+      {data.enforcesPreviousStrikes && (
+        <Alert>
+          <AlertDescription>Dette arrangementet handhever aktive prikker</AlertDescription>
+        </Alert>
+      )}
+
+      {applyInfo}
+    </>
+  );
+
+  return (
+    <div className='flex flex-col-reverse lg:flex-row gap-1 lg:gap-2 lg:mt-2'>
+      <div className='w-full lg:max-w-[335px] space-y-2'>
+        {/* Desktop sidebar info */}
+        <div className='hidden md:block'>
+          {info}
+        </div>
+      </div>
+      <div className='space-y-2 w-full'>
+        <img alt={data.title} className='rounded-md aspect-auto mx-auto' src={data.image || TIHLDE_LOGO} />
+
+        <div className='space-y-4 lg:space-y-0 lg:flex lg:items-center lg:justify-between'>
+          <div className='flex items-center space-x-2'>
+            <ShareButton shareId={data.id} shareType='event' title={data.title} />
+            {/* TODO: Re-add edit button — previously checked data.permissions.write */}
+          </div>
+          {/* TODO: Re-add emoji reactions — previously used ReactionHandler with emojis_allowed check */}
+        </div>
+
+        {/* Mobile info section */}
+        <div className='md:hidden'>
+          {info}
+        </div>
+
+        <Card>
+          <CardHeader className='pt-6 pb-2 px-6'>
+            <CardTitle className='text-4xl break-words'>{data.title}</CardTitle>
+          </CardHeader>
+          <CardContent className='py-2 px-6'>
+            {/* TODO: Re-add description rendering — the new Event schema does not include a description field yet */}
+            <p className='text-muted-foreground'>Beskrivelse er ikke tilgjengelig i den nye API-en enna.</p>
+          </CardContent>
+        </Card>
+
+        {data.updatedAt && <UpdatedAgo updatedAt={data.updatedAt} />}
+      </div>
+    </div>
+  );
+};
+
+export default EventRenderer;
+
+export const EventRendererLoading = () => (
+  <div className='flex flex-col-reverse lg:flex-row gap-1 lg:gap-2 lg:mt-2'>
+    <div className='w-full lg:max-w-[335px] space-y-2'>
+      <Skeleton className='w-full h-60' />
+      <Skeleton className='w-full h-32' />
+      <Skeleton className='w-full h-20' />
+    </div>
+
+    <div className='space-y-2 w-full'>
+      <Skeleton className='w-full h-96' />
+      <Skeleton className='w-full h-60' />
+    </div>
+  </div>
+);

--- a/src/routes/events/components/EventsDefaultView.tsx
+++ b/src/routes/events/components/EventsDefaultView.tsx
@@ -1,0 +1,5 @@
+import EventFilterView from './EventFilterView';
+
+const EventsDefaultView = () => <EventFilterView />;
+
+export default EventsDefaultView;

--- a/src/routes/events/components/useScanner.ts
+++ b/src/routes/events/components/useScanner.ts
@@ -1,0 +1,45 @@
+import QrScanner from 'qr-scanner';
+import { useEffect } from 'react';
+
+export type ScannerOptions = {
+  color?: 'dark' | 'light' | 'both';
+  onResult?: (result: QrScanner.ScanResult) => void;
+  onError?: (error: Error | string) => void;
+  maxScansPerSecond?: number;
+  cameraPreference?: QrScanner.FacingMode | QrScanner.DeviceId;
+};
+
+// Sourced from: https://github.com/jakub-ucinski/qr-scanner-react/blob/cf465602c9967b71717c271d32892cfeb14ff7c9/src/hooks/useScanner.tsx
+export function useScanner(
+  vid: React.RefObject<HTMLVideoElement | null>,
+  { onResult = () => {}, color = 'both', maxScansPerSecond = 5, onError = () => {}, cameraPreference = 'environment' }: ScannerOptions,
+) {
+  const inversion = (color && color === 'dark' && 'original') || (color && color === 'light' && 'invert') || 'both';
+
+  useEffect(() => {
+    let qrScanner: QrScanner | null = null;
+
+    if (vid.current) {
+      qrScanner = new QrScanner(vid.current, onResult, {
+        onDecodeError: onError,
+        maxScansPerSecond,
+        preferredCamera: cameraPreference,
+        highlightScanRegion: true,
+        highlightCodeOutline: true,
+      });
+
+      if (!QrScanner.hasCamera()) {
+        onError('Device has no camera');
+      } else {
+        qrScanner.setInversionMode(inversion);
+        qrScanner.start();
+      }
+    }
+
+    return (): void => {
+      qrScanner?.stop();
+      qrScanner?.destroy();
+      qrScanner = null;
+    };
+  }, [vid.current]);
+}

--- a/src/routes/events/detail.tsx
+++ b/src/routes/events/detail.tsx
@@ -1,0 +1,21 @@
+import { useSuspenseQuery } from '@tanstack/react-query';
+import { createFileRoute } from '@tanstack/react-router';
+import Page from '~/components/navigation/Page';
+import { getEventByIdQuery } from '~/api/queries/events';
+import EventRenderer from './components/EventRenderer';
+
+export const Route = createFileRoute('/_MainLayout/arrangementer/$id/{-$urlTitle}')({
+  component: EventDetails,
+});
+
+function EventDetails() {
+  const { id } = Route.useParams();
+
+  const { data: event } = useSuspenseQuery(getEventByIdQuery(id));
+
+  return (
+    <Page>
+      <EventRenderer data={event} />
+    </Page>
+  );
+}

--- a/src/routes/events/index.tsx
+++ b/src/routes/events/index.tsx
@@ -1,0 +1,54 @@
+import { createFileRoute } from '@tanstack/react-router';
+import Page from '~/components/navigation/Page';
+import { Skeleton } from '~/components/ui/skeleton';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '~/components/ui/tabs';
+import { Calendar, List, PartyPopper } from 'lucide-react';
+import { lazy, Suspense } from 'react';
+
+import EventsDefaultView from './components/EventsDefaultView';
+import ActivitiesDefaultView from './components/ActivitiesDefaultView';
+
+const EventsCalendarView = lazy(() => import('~/pages/Landing/components/EventsCalendarView'));
+
+export const Route = createFileRoute('/_MainLayout/arrangementer/')({
+  component: Events,
+});
+
+function Events() {
+  return (
+    <Page className='space-y-8 max-w-(--breakpoint-2xl) mx-auto'>
+      <div>
+        <h1 className='text-3xl md:text-5xl font-bold'>Arrangementer</h1>
+        <p className='text-muted-foreground mt-2'>Finn arrangementer for studenter</p>
+      </div>
+
+      <Tabs defaultValue='list'>
+        <TabsList>
+          <TabsTrigger value='list'>
+            <List className='mr-2 w-5 h-5 stroke-[1.5px]' />
+            Liste
+          </TabsTrigger>
+          <TabsTrigger value='activity'>
+            <PartyPopper className='mr-2 w-5 h-5 stroke-[1.5px]' />
+            Aktiviteter
+          </TabsTrigger>
+          <TabsTrigger value='calendar'>
+            <Calendar className='mr-2 w-5 h-5 stroke-[1.5px]' />
+            Kalender
+          </TabsTrigger>
+        </TabsList>
+        <TabsContent value='list'>
+          <EventsDefaultView />
+        </TabsContent>
+        <TabsContent value='activity'>
+          <ActivitiesDefaultView />
+        </TabsContent>
+        <TabsContent value='calendar'>
+          <Suspense fallback={<Skeleton className='w-full h-96' />}>
+            <EventsCalendarView />
+          </Suspense>
+        </TabsContent>
+      </Tabs>
+    </Page>
+  );
+}

--- a/src/routes/events/registration.tsx
+++ b/src/routes/events/registration.tsx
@@ -1,0 +1,171 @@
+import { useSuspenseQuery, useQuery } from '@tanstack/react-query';
+import { createFileRoute } from '@tanstack/react-router';
+import AppleAppStoreBadge from '~/assets/img/apple-appstore-badge.svg';
+import GooglePlayBadge from '~/assets/img/google-play-badge.svg';
+import NotFoundIndicator from '~/components/miscellaneous/NotFoundIndicator';
+import Page from '~/components/navigation/Page';
+import { Card, CardContent, CardHeader, CardTitle } from '~/components/ui/card';
+import { Checkbox } from '~/components/ui/checkbox';
+import { ExternalLink } from '~/components/ui/external-link';
+import { Input } from '~/components/ui/input';
+import { Label } from '~/components/ui/label';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '~/components/ui/tabs';
+import { getEventByIdQuery, getEventRegistrationsQuery } from '~/api/queries/events';
+import URLS from '~/URLS';
+import { ListChecks, QrCode } from 'lucide-react';
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { toast } from 'sonner';
+import type { CheckedState } from '@radix-ui/react-checkbox';
+import { useScanner } from './components/useScanner';
+
+// TODO: Re-add auth protection — previously used authClientWithRedirect() / userHasWritePermission(PermissionApp.EVENT)
+
+export const Route = createFileRoute('/_MainLayout/arrangementer/registrering/$id')({
+  component: EventRegistration,
+});
+
+type QrScanProps = {
+  onScan: (userId: string) => void;
+};
+
+function QrScan({ onScan }: QrScanProps) {
+  const [scanned, setScanned] = useState<string | undefined>(undefined);
+
+  useEffect(() => {
+    if (scanned) {
+      onScan(scanned);
+    }
+  }, [scanned]);
+
+  const videoRef = useRef<HTMLVideoElement>(null);
+
+  useScanner(videoRef, {
+    onResult(result) {
+      setScanned(result.data);
+    },
+    onError() {
+      setScanned(undefined);
+    },
+    maxScansPerSecond: 3,
+  });
+
+  return <video className='object-cover aspect-square w-full h-[400px]' ref={videoRef} />;
+}
+
+type ParticipantCardProps = {
+  user: { id: string; name: string };
+  onToggleAttended: (userId: string, attended: boolean) => void;
+};
+
+function ParticipantCard({ user, onToggleAttended }: ParticipantCardProps) {
+  const [checkedState, setCheckedState] = useState(false);
+
+  const onCheck = (checked: CheckedState) => {
+    setCheckedState(Boolean(checked));
+    onToggleAttended(user.id, Boolean(checked));
+  };
+
+  return (
+    <div className='p-4 flex items-center justify-between rounded-md border'>
+      <h1>{user.name}</h1>
+      <div className='items-top flex space-x-2'>
+        <Checkbox checked={checkedState} id={user.id} onCheckedChange={onCheck} />
+        <div className='grid leading-none'>
+          <label
+            className='text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70 cursor-pointer'
+            htmlFor={user.id}>
+            Ankommet
+          </label>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function EventRegistration() {
+  const { id } = Route.useParams();
+  const { data: event } = useSuspenseQuery(getEventByIdQuery(id));
+  const [search, setSearch] = useState('');
+
+  const { data: registrationsData, isLoading } = useQuery(getEventRegistrationsQuery(id, 0));
+
+  // Filter client-side since the API does not support search
+  const filteredUsers = useMemo(() => {
+    if (!registrationsData) return [];
+    const lowerSearch = search.toLowerCase();
+    return registrationsData.registeredUsers.filter(
+      (user) => !search || user.name.toLowerCase().includes(lowerSearch),
+    );
+  }, [registrationsData, search]);
+
+  // TODO: Re-add updateEventRegistration — the new API does not have a PATCH/PUT for individual registrations yet
+  const updateAttendedStatus = (_userId: string, attendedStatus: boolean) => {
+    toast.info(
+      attendedStatus
+        ? 'Registrering av ankomst er ikke implementert enna'
+        : 'Fjerning av ankomst-status er ikke implementert enna',
+    );
+  };
+
+  return (
+    <Page className='max-w-2xl w-full mx-auto'>
+      <Card>
+        <CardHeader>
+          <CardTitle>{event.title}</CardTitle>
+        </CardHeader>
+        <CardContent className='space-y-2'>
+          <Tabs defaultValue='registrations'>
+            <TabsList>
+              <TabsTrigger value='registrations'>
+                <ListChecks className='w-5 h-5 mr-2 stroke-[1.5px]' />
+                Navn
+              </TabsTrigger>
+              <TabsTrigger value='qr'>
+                <QrCode className='w-5 h-5 mr-2 stroke-[1.5px]' />
+                QR-skanner
+              </TabsTrigger>
+            </TabsList>
+            <TabsContent className='space-y-4' value='registrations'>
+              <div>
+                <Label>Sok</Label>
+                <Input onChange={(e) => setSearch(e.target.value)} placeholder='Sok etter navn' value={search} />
+              </div>
+              {!isLoading && filteredUsers.length === 0 && (
+                <NotFoundIndicator header={search ? `Ingen pameldte med navn som inneholder "${search}"` : 'Ingen pameldte'} />
+              )}
+
+              <div className='space-y-2'>
+                {filteredUsers.map((user) => (
+                  <ParticipantCard
+                    key={user.id}
+                    onToggleAttended={updateAttendedStatus}
+                    user={user}
+                  />
+                ))}
+              </div>
+            </TabsContent>
+            <TabsContent value='qr'>
+              <div>
+                <div className='flex flex-col items-center space-y-4 mb-4'>
+                  <p className='text-muted-foreground text-center'>
+                    Vi kommer til a fjerne QR-Scanneren fra nettsiden i fremtiden. Du finner en bedre QR-Scanner i{' '}
+                    <strong className='text-foreground'>TIHLDE appen</strong>. Bytt over for en bedre opplevelse!
+                  </p>
+                  <div>
+                    <ExternalLink href={URLS.external.mobileApp.iOS}>
+                      <img src={AppleAppStoreBadge} alt='Last ned iPhone-appen' className='inline-block w-auto h-12' />
+                    </ExternalLink>{' '}
+                    <ExternalLink href={URLS.external.mobileApp.Android}>
+                      <img src={GooglePlayBadge} alt='Last ned Android-appen' className='inline-block w-auto h-12' />
+                    </ExternalLink>
+                  </div>
+                </div>
+                <QrScan onScan={(userId) => updateAttendedStatus(userId, true)} />
+              </div>
+            </TabsContent>
+          </Tabs>
+        </CardContent>
+      </Card>
+    </Page>
+  );
+}


### PR DESCRIPTION
## Summary
- Move Events list, EventDetails, and EventRegistration from `src/pages/` to `src/routes/events/`
- Replace old hooks with new query layer from `~/api/queries/events`
- Merge duplicate `EventsDefaultView`/`ActivitiesDefaultView` into single `EventFilterView` component
- Extract inline component declarations to prevent remount issues
- Remove auth protection with TODO comments
- Eliminate unnecessary useEffect/useState patterns

## Test plan
- [ ] Verify TypeScript compilation passes (`bun run check`)
- [ ] Test events list page with filters
- [ ] Test event detail page
- [ ] Test event registration page