### PR TITLE
Migrate Landing page to src/routes/landing/

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "@tanstack/react-router-ssr-query": "^1.141.2",
     "@tanstack/react-start": "^1.166.7",
     "@tanstack/virtual-file-routes": "^1.141.0",
+    "@tihlde/sdk": "link:@tihlde/sdk",
     "@uploadthing/react": "^7.3.3",
     "browser-image-compression": "^2.0.2",
     "canvas-confetti": "^1.9.4",

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -3,7 +3,7 @@ import { index, layout, rootRoute, route } from '@tanstack/virtual-file-routes';
 export const routes = rootRoute('./routes/__root.tsx', [
   route('/interesse', './pages/CompanyInterest/index.tsx'),
   layout('./pages/MainLayout.tsx', [
-    index('./pages/Landing/index.tsx'),
+    index('./routes/landing/index.tsx'),
     route('/ny-student', './pages/NewStudent/index.tsx'),
 
     route('tilbakemelding', './pages/Feedback/index.tsx'),

--- a/src/routes/landing/components/ActivityEventsListView.tsx
+++ b/src/routes/landing/components/ActivityEventsListView.tsx
@@ -1,0 +1,45 @@
+import EventListItem, { EventListItemLoading } from '~/components/miscellaneous/EventListItem';
+import { useQuery } from '@tanstack/react-query';
+import { getEventsQuery } from '~/api/queries/events';
+import { toOldEventListType } from '~/routes/landing/components/event-adapter';
+import { useMemo } from 'react';
+
+const NO_OF_EVENTS_TO_SHOW = 6;
+const NO_OF_EVENTS_TO_SHOW_MD_DOWN = 4;
+
+const ActivityEventsListView = () => {
+  // TODO: Add activity filter once the new API supports it
+  const { data, isLoading } = useQuery(getEventsQuery(0));
+  const events = useMemo(() => (data?.items ?? []).map(toOldEventListType), [data]);
+
+  if (isLoading) {
+    return (
+      <div className='space-y-2'>
+        <EventListItemLoading length={3} />
+      </div>
+    );
+  }
+
+  if (!events.length) {
+    return <h1 className='text-center'>Ingen kommende arrangementer</h1>;
+  }
+
+  return (
+    <>
+      {/* Mobile: limited list */}
+      <div className='space-y-2 md:hidden'>
+        {events.slice(0, NO_OF_EVENTS_TO_SHOW_MD_DOWN).map((event) => (
+          <EventListItem event={event} key={event.id} size='small' />
+        ))}
+      </div>
+      {/* Desktop: full list in grid */}
+      <div className='hidden md:grid grid-cols-2 gap-2'>
+        {events.slice(0, NO_OF_EVENTS_TO_SHOW).map((event) => (
+          <EventListItem event={event} key={event.id} size='small' />
+        ))}
+      </div>
+    </>
+  );
+};
+
+export default ActivityEventsListView;

--- a/src/routes/landing/components/EventsCalendarPopover.tsx
+++ b/src/routes/landing/components/EventsCalendarPopover.tsx
@@ -1,0 +1,63 @@
+import { Link } from '@tanstack/react-router';
+import { useQuery } from '@tanstack/react-query';
+import { getEventByIdQuery } from '~/api/queries/events';
+import { formatDate, urlEncode } from '~/utils';
+import { parseISO } from 'date-fns';
+
+import { Skeleton } from '~/components/ui/skeleton';
+
+export type EventsCalendarPopoverProps = {
+  id: number;
+};
+
+const EventsCalendarPopover = ({ id }: EventsCalendarPopoverProps) => {
+  const { data } = useQuery(getEventByIdQuery(String(id)));
+
+  // show skeleton if no data yet
+  if (!data) {
+    return (
+      <div className='space-y-2'>
+        <h1 className='font-bold text-lg'>
+          <Skeleton className='w-[200px] h-6' />
+        </h1>
+        <p className='text-sm'>
+          <Skeleton className='w-[150px] h-4' />
+        </p>
+        <p className='text-sm'>
+          <Skeleton className='w-[120px] h-4' />
+        </p>
+        <p className='text-sm'>
+          <Skeleton className='w-[220px] h-4' />
+        </p>
+        <p>
+          <Skeleton className='w-[210px] h-4' />
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className='space-y-2'>
+      <h1 className='font-bold text-lg'>{data.title}</h1>
+      <p className='text-sm'>
+        <span className='font-bold'>Fra:</span> {formatDate(parseISO(data.startTime))}
+      </p>
+      <p className='text-sm'>
+        <span className='font-bold'>Til:</span> {formatDate(parseISO(data.endTime))}
+      </p>
+      {data.location && (
+        <p className='text-sm'>
+          <span className='font-bold'>Sted:</span> {data.location}
+        </p>
+      )}
+      <Link
+        className='underline text-blue-500 dark:text-indigo-300'
+        to='/arrangementer/$id/{-$urlTitle}'
+        params={{ id: data.id.toString(), urlTitle: urlEncode(data.title) }}>
+        Til arrangement
+      </Link>
+    </div>
+  );
+};
+
+export default EventsCalendarPopover;

--- a/src/routes/landing/components/EventsCalendarView.tsx
+++ b/src/routes/landing/components/EventsCalendarView.tsx
@@ -1,0 +1,90 @@
+import { useQuery } from '@tanstack/react-query';
+import { getEventsQuery } from '~/api/queries/events';
+import { type ApiEventListItem } from '~/routes/landing/components/event-adapter';
+import { Category as CategoryEnum, Groups } from '~/types/Enums';
+import { VariantProps } from 'class-variance-authority';
+import { endOfMonth, isWithinInterval, parseISO, startOfMonth } from 'date-fns';
+import { nb } from 'date-fns/locale';
+import { ChevronLeft, ChevronRight } from 'lucide-react';
+import { useMemo, useState } from 'react';
+
+import { Card } from '~/components/ui/card';
+import {
+  Calendar,
+  CalendarCurrentDate,
+  CalendarEvent,
+  CalendarMonthView,
+  CalendarNextTrigger,
+  CalendarPrevTrigger,
+  CalendarTodayTrigger,
+  monthEventVariants,
+} from './EventsCalendarViewBase';
+
+const getColor = (event: ApiEventListItem): VariantProps<typeof monthEventVariants>['variant'] => {
+  if (event.category?.label === CategoryEnum.ACTIVITY) {
+    return 'purple';
+  }
+
+  if (
+    event.organizer?.slug.toLowerCase() === Groups.NOK.toLowerCase() ||
+    event.category?.label.toLowerCase() === CategoryEnum.COMPRES ||
+    event.category?.label.toLowerCase() === CategoryEnum.COURSE
+  ) {
+    return 'blue';
+  }
+
+  return 'orange';
+};
+
+const EventsCalendarView = () => {
+  const [monthStart, setMonthStart] = useState(() => startOfMonth(new Date()));
+
+  // TODO: Add date range and category filters once the new API supports them
+  // Fetch a large page to get events; client-side filter to current month
+  const { data } = useQuery(getEventsQuery(0, {}, 100));
+  const events = data?.items ?? [];
+
+  const monthEnd = endOfMonth(monthStart);
+
+  const displayedEvents = useMemo(() => {
+    const interval = { start: monthStart, end: monthEnd };
+    return events.reduce<CalendarEvent[]>((acc, event) => {
+      const start = parseISO(event.startTime);
+      const end = parseISO(event.endTime);
+      if (isWithinInterval(start, interval) || isWithinInterval(end, interval)) {
+        acc.push({ ...event, start, end, id: event.id.toString(), color: getColor(event) });
+      }
+      return acc;
+    }, []);
+  }, [events, monthStart, monthEnd]);
+
+  return (
+    <Calendar
+      events={displayedEvents}
+      locale={nb}
+      onSetDate={(date: Date) => {
+        setMonthStart(startOfMonth(date));
+      }}>
+      <Card className='h-dvh py-6 flex flex-col'>
+        <div className='flex px-6 items-center gap-2 mb-6'>
+          <CalendarCurrentDate />
+          <div className='flex-1' />
+          <CalendarPrevTrigger>
+            <ChevronLeft size={20} />
+            <span className='sr-only'>Forrige</span>
+          </CalendarPrevTrigger>
+          <CalendarTodayTrigger>I dag</CalendarTodayTrigger>
+          <CalendarNextTrigger>
+            <ChevronRight size={20} />
+            <span className='sr-only'>Neste</span>
+          </CalendarNextTrigger>
+        </div>
+        <div className='flex-1 overflow-auto px-6 relative'>
+          <CalendarMonthView />
+        </div>
+      </Card>
+    </Calendar>
+  );
+};
+
+export default EventsCalendarView;

--- a/src/routes/landing/components/EventsCalendarViewBase.tsx
+++ b/src/routes/landing/components/EventsCalendarViewBase.tsx
@@ -1,0 +1,559 @@
+'use client';
+
+import { Button } from '~/components/ui/button';
+import { cn } from '~/lib/utils';
+import { cva, VariantProps } from 'class-variance-authority';
+import {
+  addDays,
+  addMonths,
+  addWeeks,
+  addYears,
+  differenceInMinutes,
+  format,
+  getMonth,
+  isSameDay,
+  isSameHour,
+  isSameMonth,
+  isToday,
+  isWithinInterval,
+  Locale,
+  setHours,
+  setMonth,
+  startOfMonth,
+  startOfWeek,
+  subDays,
+  subMonths,
+  subWeeks,
+  subYears,
+} from 'date-fns';
+import { nb } from 'date-fns/locale';
+import { createContext, forwardRef, ReactNode, useCallback, useContext, useMemo, useState } from 'react';
+
+import { Popover, PopoverContent, PopoverTrigger } from '~/components/ui/popover';
+import { ScrollArea } from '~/components/ui/scroll-area';
+import EventsCalendarPopover from './EventsCalendarPopover';
+
+export const monthEventVariants = cva('size-2 rounded-full', {
+  variants: {
+    variant: {
+      default: 'bg-primary',
+      blue: 'bg-blue-500',
+      green: 'bg-green-500',
+      pink: 'bg-pink-500',
+      purple: 'bg-purple-500',
+      orange: 'bg-orange-500',
+    },
+  },
+  defaultVariants: {
+    variant: 'default',
+  },
+});
+
+const dayEventVariants = cva('font-bold border-l-4 rounded p-2 text-xs', {
+  variants: {
+    variant: {
+      default: 'bg-muted/30 text-muted-foreground border-muted',
+      blue: 'bg-blue-500/30 text-blue-600 border-blue-500',
+      green: 'bg-green-500/30 text-green-600 border-green-500',
+      pink: 'bg-pink-500/30 text-pink-600 border-pink-500',
+      purple: 'bg-purple-500/30 text-purple-600 border-purple-500',
+      orange: 'bg-orange-500/30 text-orange-600 border-orange-500',
+    },
+  },
+  defaultVariants: {
+    variant: 'default',
+  },
+});
+
+type View = 'day' | 'week' | 'month' | 'year';
+
+type ContextType = {
+  view: View;
+  setView: (view: View) => void;
+  date: Date;
+  setDate: (date: Date) => void;
+  events: CalendarEvent[];
+  locale: Locale;
+  onChangeView?: (view: View) => void;
+  onEventClick?: (event: CalendarEvent) => void;
+  enableHotkeys?: boolean;
+  today: Date;
+};
+
+const Context = createContext<ContextType>({} as ContextType);
+
+export type CalendarEvent = {
+  id: string;
+  start: Date;
+  end: Date;
+  title: string;
+  color?: VariantProps<typeof monthEventVariants>['variant'];
+};
+
+type CalendarProps = {
+  children: ReactNode;
+  defaultDate?: Date;
+  events: CalendarEvent[];
+  view?: View;
+  locale?: Locale;
+  enableHotkeys?: boolean;
+  onChangeView?: (view: View) => void;
+  onEventClick?: (event: CalendarEvent) => void;
+  onSetDate?: (date: Date) => void;
+};
+
+const Calendar = ({
+  children,
+  defaultDate = new Date(),
+  locale = nb,
+  enableHotkeys = true,
+  view: _defaultMode = 'month',
+  onEventClick,
+  events,
+  onChangeView,
+  onSetDate,
+}: CalendarProps) => {
+  const [view, setView] = useState<View>(_defaultMode);
+  const [date, _setDate] = useState(defaultDate);
+
+  const setDate = useCallback(
+    (newDate: Date) => {
+      _setDate(newDate);
+      onSetDate?.(newDate);
+    },
+    [onSetDate],
+  );
+
+  return (
+    <Context.Provider
+      value={{
+        view,
+        setView,
+        date,
+        setDate,
+        events,
+        locale,
+        enableHotkeys,
+        onEventClick,
+        onChangeView,
+        today: new Date(),
+      }}>
+      {children}
+    </Context.Provider>
+  );
+};
+
+export const useCalendar = () => useContext(Context);
+
+const CalendarViewTrigger = forwardRef<
+  HTMLButtonElement,
+  React.HTMLAttributes<HTMLButtonElement> & {
+    view: View;
+  }
+>(({ children, view, ...props }, ref) => {
+  const { view: currentView, setView, onChangeView } = useCalendar();
+
+  return (
+    <Button
+      ref={ref}
+      aria-current={currentView === view}
+      size='sm'
+      variant='ghost'
+      {...props}
+      onClick={() => {
+        setView(view);
+        onChangeView?.(view);
+      }}>
+      {children}
+    </Button>
+  );
+});
+CalendarViewTrigger.displayName = 'CalendarViewTrigger';
+
+const EventGroup = ({ events, hour }: { events: CalendarEvent[]; hour: Date }) => {
+  return (
+    <div className='h-20 border-t last:border-b'>
+      {events
+        .filter((event) => isSameHour(event.start, hour))
+        .map((event) => {
+          const hoursDifference = differenceInMinutes(event.end, event.start) / 60;
+          const startPosition = event.start.getMinutes() / 60;
+
+          return (
+            <div
+              className={cn('relative', dayEventVariants({ variant: event.color }))}
+              key={event.id}
+              style={{
+                top: `${startPosition * 100}%`,
+                height: `${hoursDifference * 100}%`,
+              }}>
+              {event.title}
+            </div>
+          );
+        })}
+    </div>
+  );
+};
+
+const CalendarDayView = () => {
+  const { view, events, date } = useCalendar();
+
+  if (view !== 'day') {
+    return null;
+  }
+
+  const hours = [...Array(24)].map((_, i) => setHours(date, i));
+
+  return (
+    <div className='flex relative pt-2 overflow-auto h-full'>
+      <TimeTable />
+      <div className='flex-1'>
+        {hours.map((hour) => (
+          <EventGroup events={events} hour={hour} key={hour.toString()} />
+        ))}
+      </div>
+    </div>
+  );
+};
+
+const CalendarWeekView = () => {
+  const { view, date, locale, events } = useCalendar();
+
+  const weekDates = useMemo(() => {
+    const start = startOfWeek(date, { weekStartsOn: 1 });
+    const weekDates = [];
+
+    for (let i = 0; i < 7; i++) {
+      const day = addDays(start, i);
+      const hours = [...Array(24)].map((_, i) => setHours(day, i));
+      weekDates.push(hours);
+    }
+
+    return weekDates;
+  }, [date]);
+
+  const headerDays = useMemo(() => {
+    const daysOfWeek = [];
+    for (let i = 0; i < 7; i++) {
+      const result = addDays(startOfWeek(date, { weekStartsOn: 1 }), i);
+      daysOfWeek.push(result);
+    }
+    return daysOfWeek;
+  }, [date]);
+
+  if (view !== 'week') {
+    return null;
+  }
+
+  return (
+    <div className='flex flex-col relative overflow-auto h-full'>
+      <div className='flex sticky top-0 bg-card z-10 border-b mb-3'>
+        <div className='w-12'></div>
+        {headerDays.map((date, i) => (
+          <div
+            className={cn(
+              'text-center flex-1 gap-1 pb-2 text-sm text-muted-foreground flex items-center justify-center',
+              [0, 6].includes(i) && 'text-muted-foreground/50',
+            )}
+            key={date.toString()}>
+            {format(date, 'E', { locale })}
+            <span className={cn('h-6 grid place-content-center', isToday(date) && 'bg-primary text-primary-foreground rounded-full size-6')}>
+              {format(date, 'd')}
+            </span>
+          </div>
+        ))}
+      </div>
+      <div className='flex flex-1'>
+        <div className='w-fit'>
+          <TimeTable />
+        </div>
+        <div className='grid grid-cols-7 flex-1'>
+          {weekDates.map((hours, i) => {
+            return (
+              <div
+                className={cn('h-full text-sm text-muted-foreground border-l first:border-l-0', [0, 6].includes(i) && 'bg-muted/50')}
+                key={hours[0].toString()}>
+                {hours.map((hour) => (
+                  <EventGroup events={events} hour={hour} key={hour.toString()} />
+                ))}
+              </div>
+            );
+          })}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+const DayTile = ({ event }: { event: CalendarEvent }) => {
+  return (
+    <Popover>
+      <PopoverTrigger asChild>
+        <div className='px-1 rounded text-sm flex items-center gap-1 cursor-pointer' key={event.id}>
+          <div className={cn('shrink-0', monthEventVariants({ variant: event.color }))}></div>
+          <span className='flex-1 truncate'>{event.title}</span>
+          <time className='tabular-nums text-muted-foreground/50 text-xs'>{format(event.start, 'HH:mm')}</time>
+        </div>
+      </PopoverTrigger>
+      <PopoverContent>
+        <EventsCalendarPopover id={parseInt(event.id)} />
+      </PopoverContent>
+    </Popover>
+  );
+};
+
+const CalendarMonthView = () => {
+  const { date, view, events, locale } = useCalendar();
+
+  const monthDates = useMemo(() => getDaysInMonth(date), [date]);
+  const weekDays = useMemo(() => generateWeekdays(locale), [locale]);
+
+  if (view !== 'month') {
+    return null;
+  }
+
+  return (
+    <div className='h-full flex flex-col'>
+      <div className='grid grid-cols-7 gap-px sticky top-0 bg-background border-b'>
+        {weekDays.map((day) => (
+          <div className={'mb-2 text-right text-sm text-foreground pr-2'} key={day}>
+            {day}
+          </div>
+        ))}
+      </div>
+      <div className='grid overflow-hidden -mt-px flex-1 auto-rows-fr p-px grid-cols-7 gap-px'>
+        {monthDates.map((_date) => {
+          const currentEvents = events.filter(
+            (event) => isSameDay(event.start, _date) || isSameDay(event.end, _date) || isWithinInterval(_date, { start: event.start, end: event.end }),
+          );
+
+          return (
+            <ScrollArea
+              className={cn('ring-1 p-2 text-sm ring-border overflow-auto', !isSameMonth(date, _date) && 'text-muted-foreground/50')}
+              key={_date.toString()}>
+              <span className={cn('size-6 grid place-items-center rounded-full mb-1 sticky top-0', isToday(_date) && 'bg-primary text-primary-foreground')}>
+                {format(_date, 'd')}
+              </span>
+
+              {currentEvents.map((event) => (
+                <DayTile event={event} key={event.id} />
+              ))}
+            </ScrollArea>
+          );
+        })}
+      </div>
+    </div>
+  );
+};
+
+const CalendarYearView = () => {
+  const { view, date, today, locale } = useCalendar();
+
+  const months = useMemo(() => {
+    if (!view) {
+      return [];
+    }
+
+    return Array.from({ length: 12 }).map((_, i) => {
+      return getDaysInMonth(setMonth(date, i));
+    });
+  }, [date, view]);
+
+  const weekDays = useMemo(() => generateWeekdays(locale), [locale]);
+
+  if (view !== 'year') {
+    return null;
+  }
+
+  return (
+    <div className='grid grid-cols-4 gap-10 overflow-auto h-full'>
+      {months.map((days, i) => (
+        <div key={days[0].toString()}>
+          <span className='text-xl'>{i + 1}</span>
+
+          <div className='grid grid-cols-7 gap-2 my-5'>
+            {weekDays.map((day) => (
+              <div className='text-center text-xs text-muted-foreground' key={day}>
+                {day}
+              </div>
+            ))}
+          </div>
+
+          <div className='grid gap-x-2 text-center grid-cols-7 text-xs tabular-nums'>
+            {days.map((_date) => {
+              return (
+                <div className={cn(getMonth(_date) !== i && 'text-muted-foreground')} key={_date.toString()}>
+                  <div
+                    className={cn(
+                      'aspect-square grid place-content-center size-full tabular-nums',
+                      isSameDay(today, _date) && getMonth(_date) === i && 'bg-primary text-primary-foreground rounded-full',
+                    )}>
+                    {format(_date, 'd')}
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+};
+
+const CalendarNextTrigger = forwardRef<HTMLButtonElement, React.HTMLAttributes<HTMLButtonElement>>(({ children, onClick, ...props }, ref) => {
+  const { date, setDate, view } = useCalendar();
+
+  const next = useCallback(() => {
+    if (view === 'day') {
+      setDate(addDays(date, 1));
+    } else if (view === 'week') {
+      setDate(addWeeks(date, 1));
+    } else if (view === 'month') {
+      setDate(addMonths(date, 1));
+    } else if (view === 'year') {
+      setDate(addYears(date, 1));
+    }
+  }, [date, view, setDate]);
+
+  return (
+    <Button
+      ref={ref}
+      size='icon'
+      variant='outline'
+      {...props}
+      onClick={(e) => {
+        next();
+        onClick?.(e);
+      }}>
+      {children}
+    </Button>
+  );
+});
+CalendarNextTrigger.displayName = 'CalendarNextTrigger';
+
+const CalendarPrevTrigger = forwardRef<HTMLButtonElement, React.HTMLAttributes<HTMLButtonElement>>(({ children, onClick, ...props }, ref) => {
+  const { date, setDate, view } = useCalendar();
+
+  const prev = useCallback(() => {
+    if (view === 'day') {
+      setDate(subDays(date, 1));
+    } else if (view === 'week') {
+      setDate(subWeeks(date, 1));
+    } else if (view === 'month') {
+      setDate(subMonths(date, 1));
+    } else if (view === 'year') {
+      setDate(subYears(date, 1));
+    }
+  }, [date, view, setDate]);
+
+  return (
+    <Button
+      ref={ref}
+      size='icon'
+      variant='outline'
+      {...props}
+      onClick={(e) => {
+        prev();
+        onClick?.(e);
+      }}>
+      {children}
+    </Button>
+  );
+});
+CalendarPrevTrigger.displayName = 'CalendarPrevTrigger';
+
+const CalendarTodayTrigger = forwardRef<HTMLButtonElement, React.HTMLAttributes<HTMLButtonElement>>(({ children, onClick, ...props }, ref) => {
+  const { setDate, today } = useCalendar();
+
+  const jumpToToday = useCallback(() => {
+    setDate(today);
+  }, [today, setDate]);
+
+  return (
+    <Button
+      ref={ref}
+      variant='outline'
+      {...props}
+      onClick={(e) => {
+        jumpToToday();
+        onClick?.(e);
+      }}>
+      {children}
+    </Button>
+  );
+});
+CalendarTodayTrigger.displayName = 'CalendarTodayTrigger';
+
+const CalendarCurrentDate = () => {
+  const { date, view } = useCalendar();
+
+  return (
+    <time className='tabular-nums font-semibold text-2xl' dateTime={date.toISOString()}>
+      {format(date, view === 'day' ? 'dd MMMM yyyy' : 'MMMM yyyy', { locale: nb })}
+    </time>
+  );
+};
+
+const TimeTable = () => {
+  const now = new Date();
+
+  return (
+    <div className='pr-2 w-12'>
+      {Array.from(Array(25).keys()).map((hour) => {
+        return (
+          <div className='text-right relative text-xs text-muted-foreground/50 h-20 last:h-0' key={hour}>
+            {now.getHours() === hour && (
+              <div
+                className='absolute z- left-full translate-x-2 w-dvw h-[2px] bg-red-500'
+                style={{
+                  top: `${(now.getMinutes() / 60) * 100}%`,
+                }}>
+                <div className='size-2 rounded-full bg-red-500 absolute left-0 top-1/2 -translate-x-1/2 -translate-y-1/2'></div>
+              </div>
+            )}
+            <p className='top-0 -translate-y-1/2'>{hour === 24 ? 0 : hour}:00</p>
+          </div>
+        );
+      })}
+    </div>
+  );
+};
+
+const getDaysInMonth = (date: Date) => {
+  const startOfMonthDate = startOfMonth(date);
+  const startOfWeekForMonth = startOfWeek(startOfMonthDate, {
+    weekStartsOn: 1,
+  });
+
+  let currentDate = startOfWeekForMonth;
+  const calendar = [];
+
+  while (calendar.length < 42) {
+    calendar.push(new Date(currentDate));
+    currentDate = addDays(currentDate, 1);
+  }
+
+  return calendar;
+};
+
+const generateWeekdays = (locale: Locale) => {
+  const daysOfWeek = [];
+  for (let i = 0; i < 7; i++) {
+    const date = addDays(startOfWeek(new Date(), { weekStartsOn: 1 }), i);
+    daysOfWeek.push(format(date, 'EEEEEE', { locale }));
+  }
+  return daysOfWeek;
+};
+
+export {
+  Calendar,
+  CalendarCurrentDate,
+  CalendarDayView,
+  CalendarMonthView,
+  CalendarNextTrigger,
+  CalendarPrevTrigger,
+  CalendarTodayTrigger,
+  CalendarViewTrigger,
+  CalendarWeekView,
+  CalendarYearView,
+};

--- a/src/routes/landing/components/EventsListView.tsx
+++ b/src/routes/landing/components/EventsListView.tsx
@@ -1,0 +1,85 @@
+import EventListItem, { EventListItemLoading } from '~/components/miscellaneous/EventListItem';
+import type { EventList } from '~/types';
+import { Category, Groups } from '~/types/Enums';
+
+export type EventsListViewProps = {
+  events: Array<EventList>;
+  isLoading?: boolean;
+};
+
+const NO_OF_EVENTS_TO_SHOW = 3;
+const NO_OF_EVENTS_TO_SHOW_MD_DOWN = 4;
+
+const EventsListView = ({ events, isLoading = false }: EventsListViewProps) => {
+  if (isLoading) {
+    return (
+      <>
+        {/* Mobile: simple list */}
+        <div className='space-y-2 md:hidden'>
+          <EventListItemLoading length={3} />
+        </div>
+        {/* Desktop: two-column grid */}
+        <div className='hidden md:grid grid-cols-2 gap-2'>
+          <div className='space-y-2'>
+            <EventListItemLoading length={3} />
+          </div>
+          <div className='space-y-2'>
+            <EventListItemLoading length={3} />
+          </div>
+        </div>
+      </>
+    );
+  }
+
+  if (!events.length) {
+    return <h1 className='text-center'>Ingen kommende arrangementer</h1>;
+  }
+
+  const nokEvents = events
+    .filter(
+      (event) =>
+        event.organizer?.slug.toLowerCase() === Groups.NOK.toLowerCase() ||
+        event.category?.text.toLowerCase() === 'bedpres' ||
+        event.category?.text.toLowerCase() === 'kurs',
+    )
+    .slice(0, NO_OF_EVENTS_TO_SHOW);
+
+  const otherEvents = events
+    .filter(
+      (event) =>
+        event.organizer?.slug.toLowerCase() !== Groups.NOK.toLowerCase() &&
+        event.category?.text.toLowerCase() !== Category.COMPRES &&
+        event.category?.text.toLowerCase() !== Category.COURSE,
+    )
+    .slice(0, NO_OF_EVENTS_TO_SHOW);
+
+  return (
+    <>
+      {/* Mobile: single list of all events */}
+      <div className='space-y-2 md:hidden'>
+        {events.slice(0, NO_OF_EVENTS_TO_SHOW_MD_DOWN).map((event) => (
+          <EventListItem event={event} key={event.id} size='small' />
+        ))}
+      </div>
+      {/* Desktop: two-column split by event type */}
+      <div className='hidden md:grid grid-cols-2 gap-2'>
+        <div className='space-y-2'>
+          {nokEvents.length ? (
+            nokEvents.map((event) => <EventListItem event={event} key={event.id} size='small' />)
+          ) : (
+            <h1 className='text-center'>Ingen kommende bedpres eller kurs</h1>
+          )}
+        </div>
+        <div className='space-y-2'>
+          {otherEvents.length ? (
+            otherEvents.map((event) => <EventListItem event={event} key={event.id} size='small' />)
+          ) : (
+            <h1 className='text-center'>Ingen kommende sosiale eller andre arrangementer</h1>
+          )}
+        </div>
+      </div>
+    </>
+  );
+};
+
+export default EventsListView;

--- a/src/routes/landing/components/EventsView.tsx
+++ b/src/routes/landing/components/EventsView.tsx
@@ -1,0 +1,51 @@
+import { Skeleton } from '~/components/ui/skeleton';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '~/components/ui/tabs';
+import { useQuery } from '@tanstack/react-query';
+import { getEventsQuery } from '~/api/queries/events';
+import EventsListView from '~/routes/landing/components/EventsListView';
+import { toOldEventListType } from '~/routes/landing/components/event-adapter';
+import { Calendar, List, PartyPopper } from 'lucide-react';
+import { lazy, Suspense, useMemo } from 'react';
+
+import ActivityEventsListView from './ActivityEventsListView';
+
+const EventsCalendarView = lazy(() => import('~/routes/landing/components/EventsCalendarView'));
+
+const EventsView = () => {
+  const { data, isLoading } = useQuery(getEventsQuery(0));
+  const events = useMemo(() => (data?.items ?? []).map(toOldEventListType), [data]);
+
+  return (
+    <Tabs defaultValue='list'>
+      <div className='w-full flex justify-center'>
+        <TabsList>
+          <TabsTrigger value='list'>
+            <List className='mr-2 w-5 h-5 stroke-[1.5px]' />
+            Liste
+          </TabsTrigger>
+          <TabsTrigger value='activity'>
+            <PartyPopper className='mr-2 w-5 h-5 stroke-[1.5px]' />
+            Aktiviteter
+          </TabsTrigger>
+          <TabsTrigger value='calendar'>
+            <Calendar className='mr-2 w-5 h-5 stroke-[1.5px]' />
+            Kalender
+          </TabsTrigger>
+        </TabsList>
+      </div>
+      <TabsContent value='list'>
+        <EventsListView events={events} isLoading={isLoading} />
+      </TabsContent>
+      <TabsContent value='activity'>
+        <ActivityEventsListView />
+      </TabsContent>
+      <TabsContent value='calendar'>
+        <Suspense fallback={<Skeleton className='h-60' />}>
+          <EventsCalendarView />
+        </Suspense>
+      </TabsContent>
+    </Tabs>
+  );
+};
+
+export default EventsView;

--- a/src/routes/landing/components/NewStudentBox.tsx
+++ b/src/routes/landing/components/NewStudentBox.tsx
@@ -1,0 +1,82 @@
+import { Link } from '@tanstack/react-router';
+import { Button } from '~/components/ui/button';
+import { SHOW_FADDERUKA_INFO, SHOW_NEW_STUDENT_INFO } from '~/constant';
+import { useOptionalAuth } from '~/hooks/auth';
+import { useAnalytics, usePersistedState } from '~/hooks/Utils';
+import URLS from '~/URLS';
+import { getYear } from 'date-fns';
+import { ArrowRight, ArrowUpRightFromSquare } from 'lucide-react';
+import { useMemo } from 'react';
+
+const NewStudentBox = () => {
+  const { event } = useAnalytics();
+  const { auth } = useOptionalAuth();
+  const isAuthenticated = auth != null;
+  // TODO: auth.tihldeUser provides basic user info; full user profile may need a dedicated query
+  const user = auth?.tihldeUser ?? null;
+  const [shouldShowBox, setShouldShowBox] = usePersistedState('ShowNewStudentBox', true, 1000 * 3600 * 24 * 60);
+  const HEADER = {
+    NEW_STUDENT: 'Nye studenter',
+    OLD_STUDENT: 'Velkommen tilbake',
+  };
+  const TEXT = {
+    NEW_STUDENT: `Hei, ${user?.first_name} Velkommen som ny student i TIHLDE! Vi gleder oss til å bli kjent med deg og håper at du vil være med på fadderuka og engasjere deg i linjeforeningen. Les alt på siden for nye studenter`,
+    OLD_STUDENT: `Hei, ${user?.first_name} Velkommen tilbake til et nytt semester! Håper du har hatt en strålende sommer og er gira på å komme i gang igjen. Husk at det er lurt å sjekke nettsiden jevnlig for nye kule arrangementer og stillingsannonser`,
+    NO_AUTH:
+      'Velkommen til alle nye studenter i TIHLDE Vi gleder oss til å bli kjent med dere og håper at dere vil være med på fadderuka og engasjere dere i linjeforeningen. Les alt om fadderuka, verv og FAQ på siden for nye studenter',
+  };
+
+  const [header, text] = useMemo(() => {
+    if (user) {
+      if (user.studyyear?.group?.name === `${getYear(new Date())}`) {
+        return [HEADER.NEW_STUDENT, TEXT.NEW_STUDENT];
+      } else {
+        return [HEADER.OLD_STUDENT, TEXT.OLD_STUDENT];
+      }
+    } else {
+      return [HEADER.NEW_STUDENT, TEXT.NO_AUTH];
+    }
+  }, [user]);
+
+  if (!SHOW_NEW_STUDENT_INFO || header === '' || !shouldShowBox || (isAuthenticated && SHOW_NEW_STUDENT_INFO && !SHOW_FADDERUKA_INFO)) {
+    return null;
+  }
+
+  const hideBox = () => {
+    setShouldShowBox(false);
+    event('hide-box', 'new-student', 'Hide new student box on landing page');
+  };
+  const fadderukaSignupAnalytics = () => event('signup-fadderuka-from-box', 'new-student', 'Clicked on link to signup for fadderuka');
+
+  return (
+    <div className='p-4 rounded-md border max-w-3xl w-full mx-auto space-y-4'>
+      <h1 className='text-center text-4xl font-bold'>{header}</h1>
+      <p className='text-center'>{text}</p>
+      {header === HEADER.NEW_STUDENT && (
+        <div className='space-y-2 md:space-y-0 md:flex md:items-center md:space-x-4 md:justify-center pt-4 pb-2'>
+          <Button asChild className='w-full'>
+            <Link to={URLS.newStudent}>
+              Nye studenter
+              <ArrowRight className='ml-2 w-5 h-5 stroke-[1.5px]' />
+            </Link>
+          </Button>
+          {SHOW_FADDERUKA_INFO && (
+            <Button asChild className='w-full' variant='outline'>
+              <a href='https://forms.gle/oJa8sQrkQfGq6vcNA' onClick={fadderukaSignupAnalytics} rel='noopener noreferrer' target='_blank'>
+                Meld deg på fadderuka
+                <ArrowUpRightFromSquare className='ml-2 w-5 h-5 stroke-[1.5px]' />
+              </a>
+            </Button>
+          )}
+        </div>
+      )}
+      {isAuthenticated && (
+        <Button className='w-full' onClick={hideBox} variant='outline'>
+          Ikke vis igjen
+        </Button>
+      )}
+    </div>
+  );
+};
+
+export default NewStudentBox;

--- a/src/routes/landing/components/NewsListView.tsx
+++ b/src/routes/landing/components/NewsListView.tsx
@@ -1,0 +1,53 @@
+import NewsListItem, { NewsListItemLoading } from '~/components/miscellaneous/NewsListItem';
+import { useQuery } from '@tanstack/react-query';
+import { getNewsQuery } from '~/api/queries/news';
+import type { News } from '~/types';
+
+const NO_OF_NEWS_TO_SHOW = 2;
+
+// TODO: Remove this adapter once NewsListItem is migrated to new API types
+function toOldNewsType(item: {
+  id: string;
+  title: string;
+  header: string;
+  body: string;
+  imageUrl: string | null;
+  imageAlt: string | null;
+  createdAt: string;
+  updatedAt: string;
+}): News {
+  return {
+    id: Number(item.id) || 0,
+    title: item.title,
+    header: item.header,
+    body: item.body,
+    image: item.imageUrl ?? undefined,
+    image_alt: item.imageAlt ?? undefined,
+    created_at: item.createdAt,
+    updated_at: item.updatedAt,
+    creator: null,
+    emojis_allowed: false,
+    reactions: [],
+  };
+}
+
+const NewsListView = () => {
+  const { data, isLoading } = useQuery(getNewsQuery(0));
+  const news = (data?.items ?? []).map(toOldNewsType);
+
+  if (isLoading) {
+    return <NewsListItemLoading />;
+  } else if (news.length) {
+    return (
+      <div className='grid md:grid-cols-2 gap-4'>
+        {news.slice(0, NO_OF_NEWS_TO_SHOW).map((newsItem, index) => (
+          <NewsListItem key={index} news={newsItem} />
+        ))}
+      </div>
+    );
+  } else {
+    return <h1 className='text-center '>Fant ingen nyheter</h1>;
+  }
+};
+
+export default NewsListView;

--- a/src/routes/landing/components/StoriesView.tsx
+++ b/src/routes/landing/components/StoriesView.tsx
@@ -1,0 +1,29 @@
+import { useQuery } from '@tanstack/react-query';
+import { getEventsQuery } from '~/api/queries/events';
+import { getJobsQuery } from '~/api/queries/jobs';
+import { getNewsQuery } from '~/api/queries/news';
+import Story, { StoryLoading } from '~/routes/landing/components/Story';
+import { useMemo } from 'react';
+
+const STORIES_TO_DISPLAY = 10;
+
+const StoriesView = () => {
+  const { data: news, isLoading: isNewsLoading } = useQuery(getNewsQuery(0));
+  const { data: jobposts, isLoading: isJobPostsLoading } = useQuery(getJobsQuery(0));
+  const { data: events, isLoading: isEventsLoading } = useQuery(getEventsQuery(0));
+  const items = useMemo(
+    () =>
+      [...(events?.items || []), ...(jobposts?.items || []), ...(news?.items || [])]
+        .sort((a, b) => b.updatedAt.localeCompare(a.updatedAt))
+        .slice(0, STORIES_TO_DISPLAY),
+    [events, jobposts, news],
+  );
+
+  if (isNewsLoading || isJobPostsLoading || isEventsLoading) {
+    return <StoryLoading />;
+  } else {
+    return <Story items={items} />;
+  }
+};
+
+export default StoriesView;

--- a/src/routes/landing/components/Story.tsx
+++ b/src/routes/landing/components/Story.tsx
@@ -1,0 +1,106 @@
+import { Link } from '@tanstack/react-router';
+import AspectRatioImg from '~/components/miscellaneous/AspectRatioImg';
+import { ScrollArea, ScrollBar } from '~/components/ui/scroll-area';
+import { Skeleton } from '~/components/ui/skeleton';
+import URLS from '~/URLS';
+import { urlEncode } from '~/utils';
+import { useMemo } from 'react';
+
+export type StoryItem = {
+  link: string;
+  title: string;
+  image?: string | null;
+  typeText: string;
+};
+
+type EventItem = { id: string; title: string; image: string | null; startTime: string; updatedAt: string };
+type NewsItem = { id: string; title: string; imageUrl: string | null; header: string; updatedAt: string };
+type JobItem = { id: string; title: string; imageUrl: string | null; company: string; updatedAt: string };
+
+type AnyItem = EventItem | NewsItem | JobItem;
+
+const isEvent = (item: AnyItem): item is EventItem => 'startTime' in item;
+const isNews = (item: AnyItem): item is NewsItem => 'header' in item;
+const isJob = (item: AnyItem): item is JobItem => 'company' in item;
+
+export type StoryProps = {
+  items: Array<AnyItem>;
+};
+
+const Story = ({ items }: StoryProps) => {
+  const storyItems = useMemo(() => {
+    const newItems: Array<StoryItem> = [];
+    items.forEach((item) => {
+      if (isEvent(item)) {
+        newItems.push({
+          title: item.title,
+          image: item.image,
+          link: `${URLS.events}/${item.id}/${urlEncode(item.title)}/`,
+          typeText: 'Arr.',
+        });
+      } else if (isJob(item)) {
+        newItems.push({
+          title: item.title,
+          image: item.imageUrl,
+          link: `${URLS.jobposts}/${item.id}/${urlEncode(item.title)}/`,
+          typeText: 'Ann.',
+        });
+      } else if (isNews(item)) {
+        newItems.push({
+          title: item.title,
+          image: item.imageUrl,
+          link: `${URLS.news}/${item.id}/${urlEncode(item.title)}/`,
+          typeText: 'Nyh.',
+        });
+      }
+    });
+    return newItems;
+  }, [items]);
+
+  type StoryItemViewProps = {
+    item: StoryItem;
+  };
+
+  const StoryItemView = ({ item }: StoryItemViewProps) => {
+    return (
+      <div className='space-y-2 max-w-[110px] w-full'>
+        <Link className='relative block' to={item.link}>
+          <AspectRatioImg alt={item.title} src={item.image ?? undefined} />
+          <div className='absolute bottom-0.5 left-0.5 p-1 rounded-sm bg-card bg-opacity-70'>
+            <p className='text-[8px]'>{item.typeText}</p>
+          </div>
+        </Link>
+
+        <p className='text-sm text-center w-full whitespace-nowrap overflow-hidden text-ellipsis'>{item.title}</p>
+      </div>
+    );
+  };
+
+  return (
+    <ScrollArea className='w-full py-2'>
+      <div className='flex w-max space-x-2'>
+        {storyItems.map((item, index) => (
+          <StoryItemView item={item} key={index} />
+        ))}
+      </div>
+      <ScrollBar orientation='horizontal' />
+    </ScrollArea>
+  );
+};
+export default Story;
+
+export const StoryLoading = () => {
+  return (
+    <ScrollArea className='w-full'>
+      <div className='flex w-max space-x-2'>
+        {Array.from({ length: 10 }).map((_, index) => (
+          <div className='space-y-2 w-[110px]' key={index}>
+            <Skeleton className='h-12' />
+            <Skeleton className='h-4 w-3/4 mx-auto' />
+          </div>
+        ))}
+      </div>
+      <ScrollBar orientation='horizontal' />
+    </ScrollArea>
+  );
+};

--- a/src/routes/landing/components/Wave.tsx
+++ b/src/routes/landing/components/Wave.tsx
@@ -1,0 +1,132 @@
+import { Link } from '@tanstack/react-router';
+import TihldeLogo from '~/components/miscellaneous/TihldeLogo';
+import { Button } from '~/components/ui/button';
+import { useOptionalAuth } from '~/hooks/auth';
+import { useAnalytics } from '~/hooks/Utils';
+import { isAfterDateOfYear, isBeforeDateOfYear } from '~/utils';
+import { LogIn, Plus, User } from 'lucide-react';
+
+const Wave = () => {
+  const { event } = useAnalytics();
+  const { auth } = useOptionalAuth();
+  const isAuthenticated = auth != null;
+
+  const analytics = (page: string) => event('go-to-page', 'wave', `Go to ${page}`);
+
+  return (
+    <div className='w-full h-[600px]'>
+      <div className='overflow-hidden absolute w-full h-[600px] bg-linear-to-tr from-indigo-200 to-white dark:from-indigo-900 dark:to-background'>
+        <div className='max-w-[920px] relative z-20 pt-[150px] px-[15px] pb-[100px] m-auto'>
+          <TihldeLogo className='w-[70vw] max-w-[450px] min-w-[250px] max-h-[90px] text-primary' size='large' />
+          <h1 className='text-center md:text-lg py-2'>
+            Linjeforeningen for Dataingeniør, Digital infrastruktur og cybersikkerhet, Digital forretningsutvikling, Digital transformasjon og
+            Informasjonsbehandling ved NTNU
+          </h1>
+          <div className='flex items-center space-x-4 justify-center mt-4'>
+            {isAuthenticated ? (
+              <Button asChild className='text-black dark:text-white' onClick={() => analytics('profile')} variant='outline'>
+                <Link to='/profil/{-$userId}'>
+                  <User className='mr-2 w-5 h-5 stroke-[1.5px]' />
+                  Min profil
+                </Link>
+              </Button>
+            ) : (
+              <>
+                <Button asChild className='text-black dark:text-white' onClick={() => analytics('profile')} variant='outline'>
+                  <Link to='/profil/{-$userId}'>
+                    <LogIn className='mr-2 w-5 h-5 stroke-[1.5px]' />
+                    Logg inn
+                  </Link>
+                </Button>
+                <Button asChild className='text-black dark:text-white' onClick={() => analytics('profile')} variant='ghost'>
+                  <Link to='/ny-bruker'>
+                    <Plus className='mr-2 w-5 h-5 stroke-[1.5px]' />
+                    Opprett bruker
+                  </Link>
+                </Button>
+              </>
+            )}
+          </div>
+        </div>
+        {/* Show snow if between November 15th and February 1st */}
+        {(isAfterDateOfYear(10, 15) || isBeforeDateOfYear(1, 1)) && (
+          <>
+            <div className='rain rain--far' />
+            <div className='rain rain--mid' />
+            <div className='rain rain--near' />
+          </>
+        )}
+
+        <div className='absolute left-0 right-0 bottom-0 w-full overflow-hidden h-[130px] z-15'>
+          <div className='absolute left-0 bottom-0 w-[200%] h-full fill-[#f2f2f2] dark:fill-[#071a2d] animate-wave-top z-10 opacity-50 origin-bottom'>
+            <WaveSvg className='absolute w-full h-[200px]' type='top' />
+            <WaveSvg className='absolute w-full h-[200px]' type='top' />
+          </div>
+          <div className='absolute left-0 bottom-0 w-[200%] h-full fill-[#f2f2f2] dark:fill-[#071a2d] animate-wave-middle z-5 opacity-60 origin-bottom-left'>
+            <WaveSvg className='absolute w-full h-[200px]' type='mid' />
+            <WaveSvg className='absolute w-full h-[200px]' type='mid' />
+          </div>
+          <div className='absolute left-0 bottom-0 w-[280%] h-full fill-[#f2f2f2] dark:fill-[#071a2d] animate-wave-bottom z-1 opacity-70 origin-bottom-right'>
+            <WaveSvg className='absolute w-full h-[200px]' type='btm' />
+            <WaveSvg className='absolute w-full h-[200px]' type='btm' />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default Wave;
+
+type WaveSvgProps = {
+  className?: string;
+  type: 'top' | 'mid' | 'btm';
+};
+function WaveSvg({ className, type }: WaveSvgProps) {
+  if (type === 'top') {
+    return (
+      <svg
+        className={className}
+        height='119pt'
+        preserveAspectRatio='none'
+        version='1.0'
+        viewBox='0 0 1920 119'
+        width='1920pt'
+        xmlns='http://www.w3.org/2000/svg'>
+        <g stroke='none' transform='translate(0,119) scale(0.1,-0.1)'>
+          <path d='M0 592 l0 -592 9600 0 9600 0 0 592 0 591 -202 -7 c-537 -18 -1061 -71 -2398 -241 -1857 -236 -2519 -295 -3321 -295 -808 0 -1384 59 -2769 285 -869 141 -1176 183 -1605 220 -656 55 -1173 43 -1765 -41 -369 -53 -719 -126 -1485 -309 -569 -135 -908 -201 -1260 -242 -190 -22 -747 -25 -930 -5 -402 44 -657 99 -1315 282 -886 248 -1318 324 -1952 346 l-198 7 0 -591z' />
+        </g>
+      </svg>
+    );
+  } else if (type === 'mid') {
+    return (
+      <svg
+        className={className}
+        height='167pt'
+        preserveAspectRatio='none'
+        version='1.0'
+        viewBox='0 0 1920 167'
+        width='1920pt'
+        xmlns='http://www.w3.org/2000/svg'>
+        <g stroke='none' transform='translate(0,167) scale(0.1,-0.1)'>
+          <path d='M0 832 l0 -832 9600 0 9600 0 0 830 0 830 -67 0 c-295 -1 -926 -51 -1513 -121 -838 -100 -1519 -203 -3560 -544 -2521 -420 -2893 -466 -3240 -400 -269 51 -484 136 -1085 428 -639 309 -931 426 -1311 521 -322 82 -564 111 -919 110 -287 0 -425 -10 -703 -50 -427 -61 -747 -144 -1477 -384 -1010 -332 -1357 -402 -1915 -387 -525 15 -920 108 -1615 383 -853 337 -1161 420 -1637 440 l-158 7 0 -831z' />
+        </g>
+      </svg>
+    );
+  } else {
+    return (
+      <svg
+        className={className}
+        height='219pt'
+        preserveAspectRatio='none'
+        version='1.0'
+        viewBox='0 0 1920 219'
+        width='1920pt'
+        xmlns='http://www.w3.org/2000/svg'>
+        <g stroke='none' transform='translate(0,219) scale(0.1,-0.1)'>
+          <path d='M0 1096 l0 -1096 9600 0 9600 0 0 1096 0 1096 -122 -7 c-556 -30 -1086 -128 -2168 -401 -1025 -260 -1253 -317 -1475 -367 -1540 -354 -2283 -397 -3300 -192 -432 88 -775 185 -1615 460 -990 324 -1443 434 -2005 486 -169 16 -558 16 -710 0 -400 -42 -789 -143 -1235 -322 -228 -91 -439 -186 -900 -406 -619 -296 -890 -405 -1197 -482 -207 -52 -286 -63 -505 -68 -302 -8 -490 19 -768 109 -264 85 -506 202 -1016 489 -350 196 -600 325 -794 406 -426 180 -796 265 -1257 288 l-133 7 0 -1096z' />
+        </g>
+      </svg>
+    );
+  }
+}

--- a/src/routes/landing/components/event-adapter.ts
+++ b/src/routes/landing/components/event-adapter.ts
@@ -1,0 +1,47 @@
+import type { EventList } from '~/types';
+import type { BaseGroup } from '~/types/Group';
+import type { GroupType } from '~/types/Enums';
+
+export type ApiEventListItem = {
+  id: string;
+  slug: string;
+  title: string;
+  location?: string | null;
+  startTime: string;
+  endTime: string;
+  organizer: { name: string; slug: string; type: string } | null;
+  closed: boolean;
+  image: string | null;
+  createdAt: string;
+  updatedAt: string;
+  category: { slug: string; label: string };
+};
+
+/**
+ * Adapts the new API EventListItem to the old EventList type expected by shared components.
+ * TODO: Remove this adapter once EventListItem component is migrated to new API types.
+ */
+export function toOldEventListType(item: ApiEventListItem): EventList {
+  return {
+    id: Number(item.id) || 0,
+    title: item.title,
+    location: item.location ?? '',
+    start_date: item.startTime,
+    end_date: item.endTime,
+    updated_at: item.updatedAt,
+    expired: false,
+    image: item.image ?? undefined,
+    image_alt: item.title,
+    organizer: item.organizer
+      ? ({
+          name: item.organizer.name,
+          slug: item.organizer.slug,
+          type: item.organizer.type as GroupType,
+          image: null,
+          image_alt: null,
+          viewer_is_member: false,
+        } satisfies BaseGroup)
+      : null,
+    category: { id: 0, text: item.category.label },
+  };
+}

--- a/src/routes/landing/index.tsx
+++ b/src/routes/landing/index.tsx
@@ -1,0 +1,56 @@
+import { createFileRoute, Link } from '@tanstack/react-router';
+import InfoBanner from '~/components/miscellaneous/InfoBanner/InfoBanner';
+import { Button } from '~/components/ui/button';
+import { analyticsEvent } from '~/hooks/Utils';
+import EventsView from '~/routes/landing/components/EventsView';
+import NewsListView from '~/routes/landing/components/NewsListView';
+import NewStudentBox from '~/routes/landing/components/NewStudentBox';
+import StoriesView from '~/routes/landing/components/StoriesView';
+import Wave from '~/routes/landing/components/Wave';
+import URLS from '~/URLS';
+import { ArrowRight } from 'lucide-react';
+
+export const Route = createFileRoute('/_MainLayout/')({
+  component: Landing,
+});
+
+function Landing() {
+  const openEventsAnalytics = () => analyticsEvent('go-to-all-events', 'events-list-view', `Go to all events`);
+  const openNewsAnalytics = () => analyticsEvent('go-to-all-news', 'news-list-view', `Go to all news`);
+  return (
+    <div>
+      <Wave />
+      <div className='bg-[#f2f2f2] dark:bg-[#071a2d]'>
+        <div className='max-w-5xl w-full mx-auto py-4 space-y-8 px-4'>
+          <NewStudentBox />
+          <InfoBanner />
+          <StoriesView />
+        </div>
+      </div>
+      <div className='max-w-5xl w-full mx-auto py-4 space-y-6 px-4'>
+        <div className='flex items-center justify-center space-x-2'>
+          <h1 className='text-3xl font-bold'>Arrangementer</h1>
+          <Button asChild className='text-black dark:text-white' onClick={openEventsAnalytics} size='icon' variant='ghost'>
+            <Link to={URLS.events}>
+              <ArrowRight className='w-5 h-5' />
+            </Link>
+          </Button>
+        </div>
+        <EventsView />
+      </div>
+      <div className='bg-[#f2f2f2] dark:bg-[#071a2d]'>
+        <div className='max-w-5xl w-full mx-auto py-4 space-y-6 px-4'>
+          <div className='flex items-center justify-center space-x-2'>
+            <h1 className='text-3xl font-bold'>Nyheter</h1>
+            <Button asChild className='text-black dark:text-white' onClick={openNewsAnalytics} size='icon' variant='ghost'>
+              <Link to={URLS.news}>
+                <ArrowRight className='w-5 h-5' />
+              </Link>
+            </Button>
+          </div>
+          <NewsListView />
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Moved Landing page and all sub-components from `src/pages/Landing/` to `src/routes/landing/`
- Replaced old API hooks (`useEvents`, `useNews`, `jobPostsQuery`, `useIsAuthenticated`, `useEventById`) with new TanStack Query layers from `src/api/queries/`
- Replaced `useMediaQuery` in `EventsListView` and `ActivityEventsListView` with Tailwind responsive classes (`md:hidden`, `hidden md:block`)
- Eliminated `useEffect` in `EventsCalendarViewBase` by calling `onSetDate` directly in the `setDate` callback
- Added type adapter (`event-adapter.ts`) to bridge new API response shapes to old shared component types until those shared components are also migrated
- Updated `src/routes.ts` to point landing route to new location

## Test plan
- [ ] Verify landing page loads correctly at `/`
- [ ] Verify Wave section shows correct auth state (logged in vs logged out)
- [ ] Verify Stories carousel displays events, news, and job posts
- [ ] Verify Events tab (list, activities, calendar) all render
- [ ] Verify News section renders
- [ ] Verify responsive layout works on mobile and desktop
- [ ] TypeScript check passes (`bun run check`)