### PR TITLE
Fix waiting list participants appearing in participant list

### DIFF
--- a/src/pages/EventAdministration/components/EventParticipants.tsx
+++ b/src/pages/EventAdministration/components/EventParticipants.tsx
@@ -45,7 +45,7 @@ const Registrations = ({ onWait = false, eventId, needsSorting = false }: Regist
     };
 
     return Object.fromEntries(
-      Object.entries(values).filter(([, value]) => Boolean(value) || (typeof value === 'string' && value === 'false')),
+      Object.entries(values).filter(([, value]) => Boolean(value) || value === false || (typeof value === 'string' && value === 'false')),
     ) as Partial<EventRegistrationSearch> & {
       is_on_wait: boolean;
     };


### PR DESCRIPTION
## Summary
- Fix bug where waiting list participants incorrectly appeared in the main participant list on the event admin page
- The filter predicate dropped `is_on_wait: false` because `Boolean(false)` is falsy, so the API returned all registrations unfiltered
- Adding `value === false` to the predicate preserves boolean false values in the query params

## Test plan
- [ ] Navigate to an event admin page with both participants and a waiting list
- [ ] Confirm the participant list only shows confirmed participants
- [ ] Confirm the waiting list only shows waiting list participants
- [ ] Verify search/filter functionality still works on the participant list

🤖 Generated with [Claude Code](https://claude.com/claude-code)