### PR TITLE
Fix waiting list participants appearing in participant list (#1678)

### DIFF
--- a/src/pages/EventAdministration/components/EventParticipants.tsx
+++ b/src/pages/EventAdministration/components/EventParticipants.tsx
@@ -45,7 +45,7 @@ const Registrations = ({ onWait = false, eventId, needsSorting = false }: Regist
     };
 
     return Object.fromEntries(
-      Object.entries(values).filter(([, value]) => Boolean(value) || (typeof value === 'string' && value === 'false')),
+      Object.entries(values).filter(([, value]) => Boolean(value) || value === false || (typeof value === 'string' && value === 'false')),
     ) as Partial<EventRegistrationSearch> & {
       is_on_wait: boolean;
     };


### PR DESCRIPTION
The filter predicate dropped `is_on_wait: false` because `Boolean(false)` is falsy, causing the API to return all registrations including waiting list ones. Adding `value === false` preserves boolean false values.

## Description

closes #

Changes:

Screenshots:

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] The PR includes a picture showing visual changes
- [ ] Added Analytics-events if relevant
- [ ] CHANGELOG.md has been updated. [Guide](https://tihlde.slab.com/posts/changelog-z8hybjom)
