### PR TITLE
Add suspicious payment filter to event participants

### DIFF
--- a/src/pages/EventAdministration/components/EventStatistics.tsx
+++ b/src/pages/EventAdministration/components/EventStatistics.tsx
@@ -103,6 +103,15 @@ const EventStatistics = ({ eventId, isPaid }: EventStatisticsProps) => {
               onClick={() => handleFiltering('has_paid', 'false')}
             />
           )}
+          {Boolean(isPaid) && (
+            <Stat
+              active={Boolean(queryFilters.has_suspicious_payment)}
+              key='has_suspicious_payment'
+              label='Mistenkelig betaling'
+              number={data.suspicious_payment_count}
+              onClick={() => handleFiltering('has_suspicious_payment', 'true')}
+            />
+          )}
           <Stat
             active={Boolean(queryFilters.has_attended)}
             key='has_attended'

--- a/src/pages/EventAdministration/components/Participant.tsx
+++ b/src/pages/EventAdministration/components/Participant.tsx
@@ -13,7 +13,7 @@ import { cn } from '~/lib/utils';
 import type { Registration } from '~/types';
 import { formatDate, getUserAffiliation } from '~/utils';
 import { parseISO } from 'date-fns';
-import { BadgeCheck, ChevronDown, ChevronRight, HandCoins, NutOff } from 'lucide-react';
+import { AlertTriangle, BadgeCheck, ChevronDown, ChevronRight, HandCoins, NutOff } from 'lucide-react';
 import { useEffect, useState } from 'react';
 import { toast } from 'sonner';
 
@@ -121,6 +121,20 @@ const Participant = ({ registration, eventId }: ParticipantProps) => {
                   <TooltipPositioner>
                     <TooltipContent>
                       <p>{registration.has_paid_order ? 'Deltager har betalt' : 'Deltager har ikke betalt'}</p>
+                    </TooltipContent>
+                  </TooltipPositioner>
+                </Tooltip>
+              </TooltipProvider>
+            )}
+            {event?.is_paid_event && registration.has_suspicious_payment && (
+              <TooltipProvider>
+                <Tooltip>
+                  <TooltipTrigger>
+                    <AlertTriangle className='w-5 h-5 stroke-[1.5px] text-amber-600' />
+                  </TooltipTrigger>
+                  <TooltipPositioner>
+                    <TooltipContent>
+                      <p>Mulig dobbeltbetaling eller manglende Vipps-knapp</p>
                     </TooltipContent>
                   </TooltipPositioner>
                 </Tooltip>

--- a/src/pages/EventAdministration/eventRegistrationSearch.ts
+++ b/src/pages/EventAdministration/eventRegistrationSearch.ts
@@ -7,6 +7,7 @@ export const eventRegistrationDefaultValues = {
   has_allergy: '',
   search: '',
   has_paid: '',
+  has_suspicious_payment: '',
   allow_photo: '',
 } as const;
 
@@ -17,6 +18,7 @@ export const eventRegistrationSchema = z.object({
   has_allergy: z.string().optional().default(eventRegistrationDefaultValues.has_allergy),
   search: z.string().optional().default(eventRegistrationDefaultValues.search),
   has_paid: z.string().optional().default(eventRegistrationDefaultValues.has_paid),
+  has_suspicious_payment: z.string().optional().default(eventRegistrationDefaultValues.has_suspicious_payment),
   allow_photo: z.string().optional().default(eventRegistrationDefaultValues.allow_photo),
 });
 

--- a/src/types/Event.tsx
+++ b/src/types/Event.tsx
@@ -97,6 +97,7 @@ export type Registration = {
   user_info: UserList;
   payment_expiredate: Date;
   has_paid_order?: boolean;
+  has_suspicious_payment?: boolean;
   wait_queue_number?: number;
 };
 
@@ -113,4 +114,5 @@ export type EventStatistics = {
   has_allergy_count: number;
   has_not_paid_count: number;
   allow_photo_count: number;
+  suspicious_payment_count: number;
 };


### PR DESCRIPTION
Surfaces registrations on paid events that are either double-paid or stuck without a usable Vipps payment link, so admins can find and fix them without manual cross-referencing.

## Description

closes #

Changes:

Screenshots:

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] The PR includes a picture showing visual changes
- [ ] Added Analytics-events if relevant
- [ ] CHANGELOG.md has been updated. [Guide](https://tihlde.slab.com/posts/changelog-z8hybjom)
