### PR TITLE
Point fadderuka signup buttons to fadderuka.tihlde.org

### DIFF
--- a/src/pages/Landing/components/NewStudentBox.tsx
+++ b/src/pages/Landing/components/NewStudentBox.tsx
@@ -62,7 +62,7 @@ const NewStudentBox = () => {
           </Button>
           {SHOW_FADDERUKA_INFO && (
             <Button asChild className='w-full' variant='outline'>
-              <a href='https://forms.gle/oJa8sQrkQfGq6vcNA' onClick={fadderukaSignupAnalytics} rel='noopener noreferrer' target='_blank'>
+              <a href='https://fadderuka.tihlde.org' onClick={fadderukaSignupAnalytics} rel='noopener noreferrer' target='_blank'>
                 Meld deg på fadderuka
                 <ArrowUpRightFromSquare className='ml-2 w-5 h-5 stroke-[1.5px]' />
               </a>

--- a/src/pages/NewStudent/index.tsx
+++ b/src/pages/NewStudent/index.tsx
@@ -66,7 +66,7 @@ function NewStudent() {
           bruker om du ikke har gjort dette allerede.
         </p>
         <div className='flex flex-col md:flex-row gap-2'>
-          <a href='https://forms.gle/oJa8sQrkQfGq6vcNA' rel='noreferrer' target='_blank'>
+          <a href='https://fadderuka.tihlde.org' rel='noreferrer' target='_blank'>
             <Button className='font-semibold  bg-sky-500 text-white'>
               Meld meg på fadderuka <Users2 className='h-4' />
             </Button>
@@ -88,7 +88,7 @@ function NewStudent() {
           </p>
           <div className='flex gap-2 flex-col md:flex-row'>
             <Button asChild className='bg-sky-500 text-white font-semibold' onClick={fadderukaSignupAnalytics}>
-              <a href='https://forms.gle/oJa8sQrkQfGq6vcNA' rel='noreferrer' target='_blank'>
+              <a href='https://fadderuka.tihlde.org' rel='noreferrer' target='_blank'>
                 Meld meg på!
               </a>
             </Button>


### PR DESCRIPTION
## Endring

Alle påmeldingsknapper for fadderuka peker nå til `https://fadderuka.tihlde.org` i stedet for den gamle Google Forms-lenken.

Oppdaterte knapper:
- `NewStudentBox.tsx` — «Meld deg på fadderuka» (Landing-boks)
- `NewStudent/index.tsx` — «Meld meg på fadderuka» (hero)
- `NewStudent/index.tsx` — «Meld meg på!» (Fadderuka-seksjon)

«Hva skjer i Fadderuka?»-knappen er urørt siden den lenker til arrangementssiden, ikke påmelding. Analytics-sporing er uendret.

🤖 Generated with [Claude Code](https://claude.com/claude-code)